### PR TITLE
Auomatic generation of scope IRI

### DIFF
--- a/To_run_the_Onto_Viewer .md
+++ b/To_run_the_Onto_Viewer .md
@@ -1,6 +1,7 @@
 ﻿
 
 
+
 **
 
 ## To run the Onto-Viewer application locally compile from sources:
@@ -15,7 +16,7 @@
 
  3. Add the selected ontology in the format .ttl, .rdf, .owl in \fibo-viewer\web-app\fiboMapper.
 
- 4. In the \ fibo-viewer\web-app\config\ontology_config.xml configuration file, add a URL between the `<ontologyURL>` `</ontologyURL>` tags (where the ontology will be downloaded from) and add a URI between the `<scopeIri>` `</scopeIri>` tags, which will be treated as an IRI.
+ 4. In the \ fibo-viewer\web-app\config\ontology_config.xml configuration file, add a URL between the `<ontologyURL>` `</ontologyURL>` tags (where the ontology will be downloaded from). If there are problems with the operation of the links, add a URI between the `<scopeIri>` `</scopeIri>` tags.
 
  5. Then run the code in any program that provides effective programming tools, e.g. NetBeans, IntelliJ IDEA, etc.
 
@@ -31,7 +32,7 @@
  1. Download the file "fibo_viewer_relase.zip" from the latest version.
  2. Unpack the file.
  3. Add the selected ontology in .ttl, .rdf, .owl format in the ontologies directory.
- 4. In the ontology_config.xml configuration file, add a URL between the <ontologyURL></ontologyURL> tags (where the ontology will be downloaded from) and add a URI between the <scopeIri> </scopeIri> tags, which will be treated as an IRI.
+ 4. In the \ fibo-viewer\web-app\config\ontology_config.xml configuration file, add a URL between the `<ontologyURL>` `</ontologyURL>` tags (where the ontology will be downloaded from). If there are problems with the operation of the links, add a URI between the `<scopeIri>` `</scopeIri>` tags.
  5. At the operating system command prompt, run the following command in the folder with the latest version:
      **java -jar app-v-LAST_VERSION_NUMBER.war** for example **java -jar app-v-0.1.0.war.**
 

--- a/config-loader/src/main/java/org/edmcouncil/spec/fibo/config/configuration/model/impl/ViewerCoreConfiguration.java
+++ b/config-loader/src/main/java/org/edmcouncil/spec/fibo/config/configuration/model/impl/ViewerCoreConfiguration.java
@@ -61,8 +61,8 @@ public class ViewerCoreConfiguration implements Configuration<Set<ConfigItem>> {
 
   public boolean isOntologyLocationSet() {
     return configuration.containsKey(ConfigKeys.ONTOLOGY_URL)
-            || configuration.containsKey(ConfigKeys.ONTOLOGY_PATH)
-            || configuration.containsKey(ConfigKeys.ONTOLOGY_DIR);
+        || configuration.containsKey(ConfigKeys.ONTOLOGY_PATH)
+        || configuration.containsKey(ConfigKeys.ONTOLOGY_DIR);
   }
 
   public Map<String, Set<String>> getOntologyLocation() {
@@ -192,10 +192,10 @@ public class ViewerCoreConfiguration implements Configuration<Set<ConfigItem>> {
     Set<ConfigItem> values = configuration.getOrDefault(ConfigKeys.IGNORE_TO_DISPLAYING, new HashSet<>());
     Set<String> result = new HashSet<>();
     values.stream()
-            .map((value) -> (StringItem) value)
-            .forEachOrdered((cse) -> {
-              result.add(cse.toString());
-            });
+        .map((value) -> (StringItem) value)
+        .forEachOrdered((cse) -> {
+          result.add(cse.toString());
+        });
 
     return result;
   }
@@ -205,10 +205,10 @@ public class ViewerCoreConfiguration implements Configuration<Set<ConfigItem>> {
     Set<ConfigItem> values = configuration.getOrDefault(ConfigKeys.USER_DEFAULT_NAME_LIST, new HashSet<>());
     Set<DefaultLabelItem> result = new HashSet<>();
     values.stream()
-            .map((value) -> (DefaultLabelItem) value)
-            .forEachOrdered((cse) -> {
-              result.add(cse);
-            });
+        .map((value) -> (DefaultLabelItem) value)
+        .forEachOrdered((cse) -> {
+          result.add(cse);
+        });
 
     return result;
   }
@@ -231,6 +231,16 @@ public class ViewerCoreConfiguration implements Configuration<Set<ConfigItem>> {
       return tsc;
     }
     return null;
+  }
+
+  public Set<String> getScope() {
+    Set<ConfigItem> scopeIri = configuration.getOrDefault(ConfigKeys.SCOPE_IRI, new HashSet<>());
+    Set<String> result = new HashSet<String>();
+    for (ConfigItem configElement : scopeIri) {
+      StringItem element = (StringItem) configElement;
+      result.add(element.toString());
+    }
+    return result;
   }
 
 }

--- a/viewer-core/src/main/java/org/edmcouncil/spec/fibo/weasel/ontology/data/OwlDataHandler.java
+++ b/viewer-core/src/main/java/org/edmcouncil/spec/fibo/weasel/ontology/data/OwlDataHandler.java
@@ -3,6 +3,7 @@ package org.edmcouncil.spec.fibo.weasel.ontology.data;
 import org.edmcouncil.spec.fibo.weasel.ontology.data.handler.fibo.FiboDataHandler;
 import org.edmcouncil.spec.fibo.weasel.ontology.data.handler.AnnotationsDataHandler;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import org.edmcouncil.spec.fibo.weasel.model.details.OwlListDetails;
@@ -44,6 +45,7 @@ import org.edmcouncil.spec.fibo.weasel.ontology.data.handler.IndividualDataHandl
 import org.edmcouncil.spec.fibo.weasel.ontology.data.handler.fibo.OntoFiboMaturityLevel;
 import org.edmcouncil.spec.fibo.weasel.ontology.data.label.provider.LabelProvider;
 import org.edmcouncil.spec.fibo.weasel.ontology.factory.ViewerIdentifierFactory;
+import org.edmcouncil.spec.fibo.weasel.ontology.scope.ScopeIriOntology;
 import org.edmcouncil.spec.fibo.weasel.utils.OwlUtils;
 import org.edmcouncil.spec.fibo.weasel.utils.StringUtils;
 import org.edmcouncil.spec.fibo.weasel.utils.UrlChecker;
@@ -86,6 +88,8 @@ public class OwlDataHandler {
   private OwlUtils owlUtils;
   @Autowired
   private AppConfiguration config;
+  @Autowired
+  private ScopeIriOntology scopeIriOntology;
 
   private final Set<String> unwantedEndOfLeafIri = new HashSet<>();
 
@@ -150,6 +154,7 @@ public class OwlDataHandler {
   }
 
   private List<PropertyValue> getSubclasses(OwlDetailsProperties<PropertyValue> axioms) {
+    LOG.debug("Axiom of subclasses {}", axioms.toString());
     List<PropertyValue> subclasses = axioms
         .getProperties()
         .getOrDefault(subClassOfIriString, new ArrayList<>(0));
@@ -161,6 +166,7 @@ public class OwlDataHandler {
         .stream()
         .filter((pv) -> (pv.getType().equals(WeaselOwlType.TAXONOMY)))
         .collect(Collectors.toList());
+    LOG.debug("TaxElements: {}", taxElements.toString());
     return taxElements;
   }
 
@@ -271,11 +277,12 @@ public class OwlDataHandler {
       for (PropertyValue property : subElements) {
         if (property.getType().equals(WeaselOwlType.TAXONOMY)) {
           OwlAxiomPropertyValue axiomProperty = (OwlAxiomPropertyValue) property;
+          LOG.debug("Axiom Property {}", axiomProperty.toString());
           IRI sci = extractSubElementIri(axiomProperty, objIri);
-         //LOG.debug("Taxonomy{}", taxonomy.toString());
-//          if (sci == null) {
-//            continue;
-//          }
+          LOG.debug("Taxonomy{}", taxonomy.toString());
+          if (sci == null) {
+            continue;
+          }
 
           OWLEntity entity = createEntity(ontology, sci, type);
 
@@ -288,7 +295,7 @@ public class OwlDataHandler {
           String label = labelExtractor.getLabelOrDefaultFragment(objIri);
           //OwlTaxonomyValue val1 = new OwlTaxonomyValue(WeaselOwlType.STRING, label);
 
-       //   OwlTaxonomyValue val2 = new OwlTaxonomyValue(WeaselOwlType.IRI, objIri.getIRIString());
+          //   OwlTaxonomyValue val2 = new OwlTaxonomyValue(WeaselOwlType.IRI, objIri.getIRIString());
           OwlTaxonomyElementImpl taxEl = new OwlTaxonomyElementImpl(objIri.getIRIString(), label);
 
           if (subCLassTax.getValue().size() > 0) {
@@ -362,7 +369,10 @@ public class OwlDataHandler {
   }
 
   private IRI extractSubElementIri(OwlAxiomPropertyValue axiomProperty, IRI objIri) {
+    LOG.debug("Axiom Property SubElementIri {}", axiomProperty.toString());
+    LOG.debug("Axiom Property entityMaping {}", axiomProperty.getEntityMaping());
     for (Map.Entry<String, OwlAxiomPropertyEntity> entry : axiomProperty.getEntityMaping().entrySet()) {
+      LOG.debug("Axiom Property entry element {}", entry.toString());
       if (!entry.getValue().getIri().equals(objIri.getIRIString())) {
         return IRI.create(entry.getValue().getIri());
       }
@@ -383,6 +393,7 @@ public class OwlDataHandler {
     while (axiomsIterator.hasNext()) {
       T axiom = axiomsIterator.next();
       String value = rendering.render(axiom);
+      LOG.debug("NotRenderedAxioms: {}", axiom.toString());
 
       value = fixRenderedValue(value, iriFragment, splitFragment, fixRenderedIri);
 
@@ -424,6 +435,7 @@ public class OwlDataHandler {
     String[] splited = renderedVal.split(" ");
     String openingParenthesis = "(";
     String closingParenthesis = ")";
+    String comma = ",";
     Iterator<OWLEntity> iterator = axiom.signature().iterator();
     ViewerCoreConfiguration cfg = config.getViewerCoreConfig();
 
@@ -436,6 +448,7 @@ public class OwlDataHandler {
       String key = null;
 
       LOG.trace("OWL Entity: {}", next.toStringID());
+      LOG.trace("OWL Entity splited: {}", Arrays.asList(splited));
 
       for (int i = 0; i < splited.length; i++) {
         String string = splited[i].trim();
@@ -445,6 +458,8 @@ public class OwlDataHandler {
         int countOpeningParenthesis = StringUtils.countLetter(string, '(');
         Boolean hasClosingParenthesis = string.length() > 1 ? string.endsWith(closingParenthesis) : false;
         int countClosingParenthesis = StringUtils.countLetter(string, ')');
+        Boolean hasComma = string.length() > 1 ? string.contains(",") : false;
+        int countComma = StringUtils.countLetter(string, ',');
         if (hasOpeningParenthesis) {
           String newString = string.substring(countOpeningParenthesis);
           LOG.trace("Old string: '{}', new string '{}', count opening parenthesis '{}'", string,
@@ -460,6 +475,14 @@ public class OwlDataHandler {
 
           string = newString;
         }
+        if (hasComma) {
+          String newString = string.substring(0, string.length() - countComma);
+          LOG.trace("Old string: '{}', new string '{}', count comma '{}'", string,
+              newString,
+              countComma);
+
+          string = newString;
+        }
         if (string.equals(eSignature)) {
           String generatedKey = String.format(argPattern, i);
           key = generatedKey;
@@ -472,16 +495,20 @@ public class OwlDataHandler {
             String postfix = String.join("", Collections.nCopies(countClosingParenthesis, closingParenthesis));
             textToReplace = textToReplace + postfix;
           }
+          if (hasComma) {
+            String postfix = String.join("", Collections.nCopies(countComma, comma));
+            textToReplace = textToReplace + postfix;
+          }
           splited[i] = textToReplace;
 
           String eIri = next.getIRI().toString();
-          if (cfg.isUriIri(eIri)) {
-            parseToIri(eIri, opv, key, splited, i, splited[i]);
+          if (scopeIriOntology.scopeIri(eIri)){
+          parseToIri(eIri, opv, key, splited, i, splited[i]);
             break;
-          } else {
-            parseUrl(eIri, splited, i);
-            break;
-          }
+           } else {
+             parseUrl(eIri, splited, i);
+             break;
+            }
 
         }
 
@@ -506,11 +533,12 @@ public class OwlDataHandler {
           String generatedKey = String.format(argPattern, j);
           String key = generatedKey;
 
-          if (cfg.isUriIri(probablyUrl)) {
+          if (scopeIriOntology.scopeIri(probablyUrl)) {
             parseToIri(probablyUrl, opv, key, splited, j, generatedKey);
           } else {
             parseUrl(probablyUrl, splited, j);
           }
+
         }
       }
     }
@@ -533,6 +561,7 @@ public class OwlDataHandler {
 
   private String fixRenderedValue(String value, String iriFragment, String splitFragment, Boolean fixRenderedIri) {
     String[] split = value.split(" ");
+    LOG.debug("Split fixRenderedValue: {}", Arrays.asList(split));
     if (split[1].equals("SubClassOf")) {
       split[0] = "";
       split[1] = "";
@@ -763,16 +792,17 @@ public class OwlDataHandler {
   }
 
   public OwlListDetails handleOntologyMetadata(IRI iri, OWLOntology ontology) {
-
     OwlListDetails wd = new OwlListDetails();
     OwlDetailsProperties<PropertyValue> metadata = fiboDataHandler.handleFiboOntologyMetadata(iri, ontology, wd);
     if (metadata != null && metadata.getProperties().keySet().size() > 0) {
+
       wd.addAllProperties(metadata);
+      wd.setIri(iri.toString());
+      wd.setLabel(labelExtractor.getLabelOrDefaultFragment(iri));
+      wd.setLocationInModules(fiboDataHandler.getElementLocationInModules(iri.toString(), ontology));
+      return wd;
     }
-    wd.setIri(iri.toString());
-    wd.setLabel(labelExtractor.getLabelOrDefaultFragment(iri));
-    wd.setLocationInModules(fiboDataHandler.getElementLocationInModules(iri.toString(), ontology));
-    return wd;
+    return null;
 
   }
 

--- a/viewer-core/src/main/java/org/edmcouncil/spec/fibo/weasel/ontology/factory/CustomDataFactory.java
+++ b/viewer-core/src/main/java/org/edmcouncil/spec/fibo/weasel/ontology/factory/CustomDataFactory.java
@@ -3,6 +3,7 @@ package org.edmcouncil.spec.fibo.weasel.ontology.factory;
 import org.edmcouncil.spec.fibo.weasel.model.OwlSimpleProperty;
 import org.edmcouncil.spec.fibo.weasel.model.WeaselOwlType;
 import org.edmcouncil.spec.fibo.weasel.model.property.OwlAnnotationIri;
+import org.edmcouncil.spec.fibo.weasel.model.property.OwlAnnotationPropertyValue;
 import org.edmcouncil.spec.fibo.weasel.ontology.data.label.provider.LabelProvider;
 import org.semanticweb.owlapi.model.IRI;
 import org.slf4j.Logger;
@@ -23,12 +24,12 @@ public class CustomDataFactory {
   private LabelProvider labelExtractor;
 
   /**
-   * 
+   *
    * @param iri IRI element for which we create annotationIRI
    * @return AnnotationIri contains iri and label
    */
   public OwlAnnotationIri createAnnotationIri(String iri) {
-    LOG.debug("[Custom Data Factory] Create annotation for iri: {}", iri);
+    LOG.debug("[Custom Data Factory] Create annotation for IRI: {}", iri);
 
     OwlAnnotationIri owlAnnotationIri = new OwlAnnotationIri();
     OwlSimpleProperty osp = new OwlSimpleProperty();
@@ -38,4 +39,15 @@ public class CustomDataFactory {
     owlAnnotationIri.setType(WeaselOwlType.IRI);
     return owlAnnotationIri;
   }
+
+  public OwlAnnotationPropertyValue createAnnotationAnyUri(String iri) {
+    LOG.debug("[Custom Data Factory] Create annotation for URI: {}", iri);
+
+    OwlAnnotationPropertyValue val = new OwlAnnotationPropertyValue();
+    val.setType(WeaselOwlType.ANY_URI);
+    val.setValue(iri);
+
+    return val;
+  }
+
 }

--- a/viewer-core/src/main/java/org/edmcouncil/spec/fibo/weasel/ontology/scope/ScopeIriOntology.java
+++ b/viewer-core/src/main/java/org/edmcouncil/spec/fibo/weasel/ontology/scope/ScopeIriOntology.java
@@ -15,6 +15,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
+ * This class is resposible for automatic generation of scope IRI. ScopeIRI helps application can
+ * recognize which links are from the ontology and which should be generated outside. Many
+ * ontologies have more than one scope and the ontology scope should be generated automatically from
+ * the IRI loaded ontologies.
+ *
  * @author Patrycja Miazek (patrycja.miazek@makolab.com)
  */
 @Component
@@ -26,6 +31,12 @@ public class ScopeIriOntology {
   private AppConfiguration appConfiguration;
   private Set<String> scopes = new HashSet<String>();
 
+  /**
+   * This method return scopes IRI of ontology.
+   *
+   * @param ontology This is a loaded ontology.
+   * @return scopesOntologies These are the IRI scopes of the ontology.
+   */
   public Set<String> getScopeIri(OWLOntology ontology) {
     OWLOntologyManager manager = ontology.getOWLOntologyManager();
 

--- a/viewer-core/src/main/java/org/edmcouncil/spec/fibo/weasel/ontology/scope/ScopeIriOntology.java
+++ b/viewer-core/src/main/java/org/edmcouncil/spec/fibo/weasel/ontology/scope/ScopeIriOntology.java
@@ -1,0 +1,89 @@
+package org.edmcouncil.spec.fibo.weasel.ontology.scope;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.edmcouncil.spec.fibo.config.configuration.model.AppConfiguration;
+import org.edmcouncil.spec.fibo.weasel.ontology.updater.UpdaterThread;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Patrycja Miazek (patrycja.miazek@makolab.com)
+ */
+@Component
+public class ScopeIriOntology {
+
+  private static final Logger LOG = LoggerFactory.getLogger(UpdaterThread.class);
+
+  @Autowired
+  private AppConfiguration appConfiguration;
+  private Set<String> scopes = new HashSet<String>();
+
+  public Set<String> getScopeIri(OWLOntology ontology) {
+    OWLOntologyManager manager = ontology.getOWLOntologyManager();
+
+    Set<OWLOntology> ontologies = manager.ontologies().collect(Collectors.toSet());
+    Set<String> scopesOntologies = new HashSet<String>();
+    for (OWLOntology onto : ontologies) {
+      LOG.debug("Scope IRI ontology: {}", onto.getOntologyID());
+      Optional<IRI> ontologyVersionIri = onto.getOntologyID().getVersionIRI();
+
+      if (ontologyVersionIri.isPresent()) {
+        LOG.debug("Ontology Version IRI: {}", ontologyVersionIri.isPresent());
+        LOG.debug("Ontology Version IRI namespace: {}", ontologyVersionIri.get().getNamespace());
+        if (!ontologyVersionIri.get().getIRIString().isEmpty()) {
+          scopesOntologies.add(ontologyVersionIri.get().getIRIString());
+        }
+      }
+
+      Optional<IRI> ontologyIri = onto.getOntologyID().getOntologyIRI();
+      if (ontologyIri.isPresent()) {
+        LOG.debug("Defined ontology IRI: {}", ontologyIri.isPresent());
+        LOG.debug("Ontology IRI namespace: {}", ontologyIri.get().getNamespace());
+        if (!ontologyIri.get().getIRIString().isEmpty()) {
+          scopesOntologies.add(ontologyIri.get().getIRIString());
+        }
+      }
+      if (!ontologyIri.isPresent() && !ontologyVersionIri.isPresent()) {
+        LOG.debug("One ontology does not have an iri defined (ontology iri is not defined): {} {}", !ontologyIri.isPresent(), !ontologyVersionIri.isPresent());
+        Optional<IRI> defaultDocumentIri = onto.getOntologyID().getDefaultDocumentIRI();
+        if (defaultDocumentIri.isPresent()) {
+          LOG.debug("Default document IRI is definied: {}", defaultDocumentIri.isPresent());
+          if (!defaultDocumentIri.get().getIRIString().isEmpty()) {
+            scopesOntologies.add(defaultDocumentIri.get().getIRIString());
+          }
+        } else {
+          LOG.debug("Default document IRI is not definied: {}", !defaultDocumentIri.isPresent());
+        }
+      }
+    }
+//    Set<String> scopeConfig = appConfiguration.getViewerCoreConfig().getScope();
+//    scopesOntologies.addAll(scopeConfig) ;
+    for (String sc : scopesOntologies) {
+      LOG.debug("Difined scope: {}", sc);
+    }
+    return scopesOntologies;
+  }
+
+  public Boolean scopeIri(String uri) {
+    for (String scope : scopes) {
+      LOG.debug("Contains: {} -> {}", uri, scope);
+      if (uri.contains(scope.toString())) {
+        return Boolean.TRUE;
+      }
+    }
+    return Boolean.FALSE;
+
+  }
+
+  public void setScopes(Set<String> scopes) {
+    this.scopes = scopes;
+  }
+}

--- a/viewer-core/src/main/java/org/edmcouncil/spec/fibo/weasel/ontology/updater/Updater.java
+++ b/viewer-core/src/main/java/org/edmcouncil/spec/fibo/weasel/ontology/updater/Updater.java
@@ -8,6 +8,7 @@ import org.edmcouncil.spec.fibo.config.utils.files.FileSystemManager;
 import org.edmcouncil.spec.fibo.weasel.ontology.OntologyManager;
 import org.edmcouncil.spec.fibo.weasel.ontology.data.handler.fibo.FiboDataHandler;
 import org.edmcouncil.spec.fibo.weasel.ontology.data.label.provider.LabelProvider;
+import org.edmcouncil.spec.fibo.weasel.ontology.scope.ScopeIriOntology;
 import org.edmcouncil.spec.fibo.weasel.ontology.searcher.text.TextSearcherDb;
 import org.edmcouncil.spec.fibo.weasel.ontology.updater.model.UpdateJob;
 import org.edmcouncil.spec.fibo.weasel.ontology.updater.model.UpdateJobStatus;
@@ -39,6 +40,8 @@ public class Updater {
   @Autowired
   private FiboDataHandler fiboDataHandler;
   private final Map<String, UpdateJob> jobs = new HashMap<>();
+  @Autowired
+  private ScopeIriOntology scopeIriOntology;
 
   private static final String interruptMessage = "Interrupts this update. New update request.";
 
@@ -61,7 +64,8 @@ public class Updater {
         textSearcherDb,
         blocker,
         fiboDataHandler,
-        job) {
+        job,
+        scopeIriOntology) {
     };
     t.start();
 

--- a/web-app/config/ontology_config.xml
+++ b/web-app/config/ontology_config.xml
@@ -10,23 +10,24 @@
     <ontologyPath>AboutFIBODev.ttl</ontologyPath>-->
     <ontologyURL>https://spec.edmcouncil.org/fibo/ontology/master/latest/AboutFIBODev/</ontologyURL>
     <ontologyURL>https://spec.edmcouncil.org/fibo/ontology/master/latest/MetadataFIBO</ontologyURL> 
+   
     <ontologyDir>ontologies</ontologyDir>
     <ontologyDir>staticOntologies</ontologyDir>
     <ontologyMapper>fiboMapper</ontologyMapper>
   </ontology>
   
   <scopeIri>
-    <uriNamespace>https://spec.edmcouncil.org/fibo/ontology/AboutFIBODev/</uriNamespace>
+    <!--<uriNamespace>https://spec.edmcouncil.org/fibo/ontology/AboutFIBODev/</uriNamespace>
     <uriNamespace>http://schema.org/</uriNamespace>
-    <uriNamespace>https://spec.edmcouncil.org/fibo/ontology/</uriNamespace>
-    <uriNamespace>https://www.omg.org/spec/</uriNamespace>
+    <uriNamespace>https://spec.edmcouncil.org/fibo/ontology/</uriNamespace> 
+    <uriNamespace>https://www.omg.org/spec/</uriNamespace> 
     <uriNamespace>http://www.omg.org/techprocess</uriNamespace>
     <uriNamespace>http://www.w3.org/2002/07/owl#</uriNamespace>
     <uriNamespace>http://purl.org/dc/terms/</uriNamespace>
     <uriNamespace>http://purl.org/dc/elements/1.1/</uriNamespace>
     <uriNamespace>http://www.w3.org/2000/01/rdf-schema#</uriNamespace>
     <uriNamespace>http://www.w3.org/2004/02/skos/core#</uriNamespace>
-    <uriNamespace>http://www.w3.org/1999/02/22-rdf-syntax-ns#</uriNamespace>
+    <uriNamespace>http://www.w3.org/1999/02/22-rdf-syntax-ns#</uriNamespace> -->
   </scopeIri>
     
 


### PR DESCRIPTION
Signed-off-by: patrycjamia <patrycjamiazek17@gmail.com>

## Description

So far, the IRI scope has been defined in the configuration. Many ontologies have more than one scope and it is counterintuitive to complete this field. To skip this step, the ontology scope should be generated automatically from the IRI loaded ontologies. 
Fixed problem with redirecting a links to another pages.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings