### PR TITLE
Add 'equivalent to' type to the handle Inherited Axioms method.

### DIFF
--- a/viewer-core/src/main/java/org/edmcouncil/spec/fibo/weasel/utils/OwlUtils.java
+++ b/viewer-core/src/main/java/org/edmcouncil/spec/fibo/weasel/utils/OwlUtils.java
@@ -39,7 +39,13 @@ public class OwlUtils {
     return isRestriction;
   }
 
-  
+  /**
+   * The method collects all subclasses of the given class, excluding direct classes.
+   *
+   * @param clazz Clazz are all SubClasses of given class.
+   * @param ontology This is a loaded ontology.
+   * @return All subclasses;
+   */
   public Set<OWLClass> getSuperClasses(OWLClass clazz, OWLOntology ontology) {
     Set<OWLClass> result = new HashSet<>();
     List<OWLClassExpression> subClasses = EntitySearcher.getSuperClasses(clazz, ontology).collect(Collectors.toList());
@@ -47,7 +53,7 @@ public class OwlUtils {
       LOG.debug("getSuperClasses -> subClass {}", subClass);
       Optional<OWLEntity> e = subClass.signature().findFirst();
       LOG.debug("\tgetSuperClasses -> enity iri {}", e.get().getIRI());
-      if (subClass.getClassExpressionType() == ClassExpressionType.OWL_CLASS) { 
+      if (subClass.getClassExpressionType() == ClassExpressionType.OWL_CLASS) {
         result.add(e.get().asOWLClass());
         result.addAll(getSuperClasses(e.get().asOWLClass(), ontology));
       }

--- a/web-app/config/ontology_config.xml
+++ b/web-app/config/ontology_config.xml
@@ -6,9 +6,8 @@
   <!-- If no URL or path is provided, the program will load the ontology from the default folder -->
   <ontology>
  
-
     <ontologyURL>https://spec.edmcouncil.org/fibo/ontology/MetadataFIBO/</ontologyURL>
-    <ontologyURL>https://spec.edmcouncil.org/fibo/ontology/AboutFIBODev/</ontologyURL> 
+    <ontologyURL>https://spec.edmcouncil.org/fibo/ontology/AboutFIBODev/</ontologyURL>
     <ontologyDir>ontologies</ontologyDir>
     <ontologyDir>staticOntologies</ontologyDir>
     <ontologyMapper>fiboMapper</ontologyMapper>


### PR DESCRIPTION
Signed-off-by: patrycjamia <patrycjamiazek17@gmail.com>

## Description
Restrictions that are contained in 'equivalent to' do not displayed in 'IS-A restrictions inherited from superclasses'.
A type was handled in the 'handleInheritedAxioms' method.


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules