### PR TITLE
Repair all glitches of displaying resources

### DIFF
--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/OwlDataHandler.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/OwlDataHandler.java
@@ -615,9 +615,7 @@ public class OwlDataHandler {
       LOG.trace("OWL Entity splitted: {}", Arrays.asList(splitted));
 
       for (int i = startCountingArgs; i < startCountingArgs + splitted.length; i++) {
-          
         int fixedIValue = i - startCountingArgs;
-        
         String string = splitted[fixedIValue].trim();
         LOG.trace("Splitted string i: '{}', str: '{}'", fixedIValue, string);
         //more than 1 because when it's 1, it's a number

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/OwlDataHandler.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/OwlDataHandler.java
@@ -724,6 +724,12 @@ public class OwlDataHandler {
       String[] splited, int j, String generatedKey, String eIri, int countOpeningParenthesis,
       int countClosingParenthesis, int countComma) {
     OwlAxiomPropertyEntity axiomPropertyEntity = new OwlAxiomPropertyEntity();
+    /* I dont know why but some input iri's has '<' on start and '>' on end
+    This is not correct, so I am replacing it here with 
+    iri without these characters */
+    if(eIri.contains("<") && eIri.contains(">")){
+        eIri = eIri.toString().replace("<", "").replace(">", "");
+    }
     axiomPropertyEntity.setIri(eIri);
     LOG.debug("Probably eiri {}", eIri);
     String label = labelProvider.getLabelOrDefaultFragment(IRI.create(eIri));

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/OwlDataHandler.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/OwlDataHandler.java
@@ -563,7 +563,7 @@ public class OwlDataHandler {
       boolean bypassClass
   ) {
     String value = rendering.render(axiom);
-    LOG.debug("rendering value: {}", value);
+    LOG.debug("Rendered default value: {}", value);
     for (String unwantedType : unwantedTypes) {
       value = value.replace(unwantedType, "");
     }
@@ -615,9 +615,9 @@ public class OwlDataHandler {
       LOG.trace("OWL Entity splitted: {}", Arrays.asList(splitted));
 
       for (int i = startCountingArgs; i < startCountingArgs + splitted.length; i++) {
-
+          
         int fixedIValue = i - startCountingArgs;
-
+        
         String string = splitted[fixedIValue].trim();
         LOG.trace("Splitted string i: '{}', str: '{}'", fixedIValue, string);
         //more than 1 because when it's 1, it's a number
@@ -653,7 +653,7 @@ public class OwlDataHandler {
         }
         if (string.equals(eSignature)) {
           LOG.trace("Find match for processing item {}", string);
-          String generatedKey = String.format(argPattern, i);
+          String generatedKey = String.format(argPattern, fixedIValue);
           key = generatedKey;
           String textToReplace = generatedKey;
           if (hasOpeningParenthesis) {
@@ -672,7 +672,6 @@ public class OwlDataHandler {
           }
           LOG.trace("Prepared text: {} for: {}", textToReplace, splitted[fixedIValue]);
           splitted[fixedIValue] = textToReplace;
-
           String eIri = next.getIRI().toString();
 
           parseToIri(argPattern, opv, key, splitted, fixedIValue, generatedKey, eIri,
@@ -697,10 +696,12 @@ public class OwlDataHandler {
       OwlAxiomPropertyValue opv) {
     for (int j = 0; j < splited.length; j++) {
       String str = splited[j].trim();
+      String probablyUrl = splited[j].trim();
       if (str.startsWith("<") && str.endsWith(">")) {
         int length = str.length();
-        String probablyUrl = str.substring(1, length - 1);
-        if (UrlChecker.isUrl(probablyUrl)) {
+         probablyUrl = str.substring(1, length - 1);
+      }
+      if (UrlChecker.isUrl(probablyUrl)) {
           String generatedKey = String.format(argPattern, j);
           String key = generatedKey;
 
@@ -711,7 +712,6 @@ public class OwlDataHandler {
             parseUrl(probablyUrl, splited, j);
           }
         }
-      }
     }
   }
 
@@ -752,7 +752,9 @@ public class OwlDataHandler {
       Boolean fixRenderedIri) {
     String[] split = value.split(" ");
     LOG.debug("Split fixRenderedValue: {}", Arrays.asList(split));
-    if (split[1].equals("SubClassOf")) {
+    if (split[1].equals("SubClassOf")  
+        || split[1].equals("Domain")  
+        || split[1].equals("Range")) {
       split[0] = "";
       split[1] = "";
     }

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/label/LabelProvider.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/label/LabelProvider.java
@@ -57,12 +57,6 @@ public class LabelProvider {
 
   public String getLabelOrDefaultFragment(IRI iri) {
     var ontology = ontologyManager.getOntology();
-    /* I dont know why but some input iri's has '<' on start and '>' on end
-    This is not correct, so I am replacing it here with 
-    iri without these characters */
-    if(iri.toString().contains("<") && iri.toString().contains(">")){
-        iri = IRI.create(iri.toString().replace("<", "").replace(">", ""));
-    }
     if (previouslyUsedLabels.containsKey(iri.toString())) {
       return previouslyUsedLabels.get(iri.toString());
     }

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/label/LabelProvider.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/label/LabelProvider.java
@@ -57,11 +57,15 @@ public class LabelProvider {
 
   public String getLabelOrDefaultFragment(IRI iri) {
     var ontology = ontologyManager.getOntology();
-
+    /* I dont know why but some input iri's has '<' on start and '>' on end
+    This is not correct, so I am replacing it here with 
+    iri without these characters */
+    if(iri.toString().contains("<") && iri.toString().contains(">")){
+        iri = IRI.create(iri.toString().replace("<", "").replace(">", ""));
+    }
     if (previouslyUsedLabels.containsKey(iri.toString())) {
       return previouslyUsedLabels.get(iri.toString());
     }
-
     OWLEntity entity = ontology.entitiesInSignature(iri, Imports.INCLUDED)
         .findFirst()
         .orElse(

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/utils/StringUtils.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/utils/StringUtils.java
@@ -8,62 +8,62 @@ import org.semanticweb.owlapi.model.IRI;
  */
 public class StringUtils {
 
-    private static final String AXIOM_PATTERN = ViewerIdentifierFactory.createId(
-            ViewerIdentifierFactory.Type.axiom,
-            ViewerIdentifierFactory.Element.empty);
+  private static final String AXIOM_PATTERN = ViewerIdentifierFactory.createId(
+      ViewerIdentifierFactory.Type.axiom,
+      ViewerIdentifierFactory.Element.empty);
 
-    public static String getFragment(IRI iri) {
-        String iriString = iri.toString();
-        if (iriString.contains(AXIOM_PATTERN)) {
-            return iriString.substring(iriString.lastIndexOf(".") + 1);
-        }
-        String iriFragment = iri.getFragment();
-            return iriFragment;
+  public static String getFragment(IRI iri) {
+    String iriString = iri.toString();
+    if (iriString.contains(AXIOM_PATTERN)) {
+      return iriString.substring(iriString.lastIndexOf(".") + 1);
+    }
+    String iriFragment = iri.getFragment();
+    return iriFragment;
+  }
+
+  public static String getFragment(String iri) {
+    return getFragment(IRI.create(iri));
+  }
+
+  public static int countLetter(String string, char letter) {
+    int count = 0;
+
+    //Counts each character except space    
+    for (int i = 0; i < string.length(); i++) {
+      if (string.charAt(i) == letter) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /**
+   *
+   * @param string Given string to cutting
+   * @param length Length of output string
+   * @param soft If it set to true, string will be cut in next whitespace
+   * @return
+   */
+  public static String cutString(String string, int length, boolean soft) {
+    if (string == null || string.trim().isEmpty()) {
+      return "";
     }
 
-    public static String getFragment(String iri) {
-        return getFragment(IRI.create(iri));
-    }
-
-    public static int countLetter(String string, char letter) {
-        int count = 0;
-
-        //Counts each character except space    
-        for (int i = 0; i < string.length(); i++) {
-            if (string.charAt(i) == letter) {
-                count++;
-            }
+    StringBuilder sb = new StringBuilder(string);
+    int actualLength = length - 3;
+    if (sb.length() > actualLength) {
+      // -3 because we add 3 dots at the end. Returned string length has to be length including the dots.
+      if (!soft) {
+        return sb.insert(actualLength, "...").substring(0, actualLength + 3);
+      } else {
+        int endIndex = sb.indexOf(" ", actualLength);
+        if (endIndex == -1) {
+          return string;
         }
-        return count;
+        endIndex = endIndex >= sb.length() ? sb.length() : endIndex;
+        return sb.insert(endIndex, "...").substring(0, endIndex + 3);
+      }
     }
-
-    /**
-     *
-     * @param string Given string to cutting
-     * @param length Length of output string
-     * @param soft If it set to true, string will be cut in next whitespace
-     * @return
-     */
-    public static String cutString(String string, int length, boolean soft) {
-        if (string == null || string.trim().isEmpty()) {
-            return "";
-        }
-
-        StringBuilder sb = new StringBuilder(string);
-        int actualLength = length - 3;
-        if (sb.length() > actualLength) {
-            // -3 because we add 3 dots at the end. Returned string length has to be length including the dots.
-            if (!soft) {
-                return sb.insert(actualLength, "...").substring(0, actualLength + 3);
-            } else {
-                int endIndex = sb.indexOf(" ", actualLength);
-                if (endIndex == -1) {
-                    return string;
-                }
-                endIndex = endIndex >= sb.length() ? sb.length() : endIndex;
-                return sb.insert(endIndex, "...").substring(0, endIndex + 3);
-            }
-        }
-        return string;
-    }
+    return string;
+  }
 }

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/utils/StringUtils.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/utils/StringUtils.java
@@ -17,8 +17,7 @@ public class StringUtils {
     if (iriString.contains(AXIOM_PATTERN)) {
       return iriString.substring(iriString.lastIndexOf(".") + 1);
     }
-    String iriFragment = iri.getFragment();
-    return iriFragment;
+    return iri.getFragment();
   }
 
   public static String getFragment(String iri) {

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/utils/StringUtils.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/utils/StringUtils.java
@@ -8,70 +8,62 @@ import org.semanticweb.owlapi.model.IRI;
  */
 public class StringUtils {
 
-  private static final String AXIOM_PATTERN = ViewerIdentifierFactory.createId(
-      ViewerIdentifierFactory.Type.axiom,
-      ViewerIdentifierFactory.Element.empty);
+    private static final String AXIOM_PATTERN = ViewerIdentifierFactory.createId(
+            ViewerIdentifierFactory.Type.axiom,
+            ViewerIdentifierFactory.Element.empty);
 
-  public static String getFragment(IRI iri) {
-    String iriString = iri.toString();
-    return getFragment(iriString);
-  }
-  
-
-  public static String getFragment(String iri) {
-    if (iri.contains(AXIOM_PATTERN)) {
-      return iri.substring(iri.lastIndexOf(".")+1);
-    }
-    String[] splitIri = iri.split("/");
-    String lastElement = splitIri[splitIri.length - 1];
-    if (iri.endsWith("/")) {
-      return lastElement;
-    } else if (lastElement.contains("#")) {
-      return lastElement.substring(lastElement.indexOf("#") + 1);
-    } else {
-      return lastElement;
-    }
-  }
-
-  public static int countLetter(String string, char letter) {
-    int count = 0;
-
-    //Counts each character except space    
-    for (int i = 0; i < string.length(); i++) {
-      if (string.charAt(i) == letter) {
-        count++;
-      }
-    }
-    return count;
-  }
-
-  /**
-   *
-   * @param string Given string to cutting
-   * @param length Length of output string
-   * @param soft If it set to true, string will be cut in next whitespace
-   * @return
-   */
-  public static String cutString(String string, int length, boolean soft) {
-    if (string == null || string.trim().isEmpty()) {
-      return "";
-    }
-
-    StringBuilder sb = new StringBuilder(string);
-    int actualLength = length - 3;
-    if (sb.length() > actualLength) {
-      // -3 because we add 3 dots at the end. Returned string length has to be length including the dots.
-      if (!soft) {
-        return sb.insert(actualLength, "...").substring(0, actualLength + 3);
-      } else {
-        int endIndex = sb.indexOf(" ", actualLength);
-        if(endIndex == -1 ){
-          return string;
+    public static String getFragment(IRI iri) {
+        String iriString = iri.toString();
+        if (iriString.contains(AXIOM_PATTERN)) {
+            return iriString.substring(iriString.lastIndexOf(".") + 1);
         }
-        endIndex = endIndex >= sb.length() ? sb.length() : endIndex;
-        return sb.insert(endIndex, "...").substring(0, endIndex + 3);
-      }
+        String iriFragment = iri.getFragment();
+            return iriFragment;
     }
-    return string;
-  }
+
+    public static String getFragment(String iri) {
+        return getFragment(IRI.create(iri));
+    }
+
+    public static int countLetter(String string, char letter) {
+        int count = 0;
+
+        //Counts each character except space    
+        for (int i = 0; i < string.length(); i++) {
+            if (string.charAt(i) == letter) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /**
+     *
+     * @param string Given string to cutting
+     * @param length Length of output string
+     * @param soft If it set to true, string will be cut in next whitespace
+     * @return
+     */
+    public static String cutString(String string, int length, boolean soft) {
+        if (string == null || string.trim().isEmpty()) {
+            return "";
+        }
+
+        StringBuilder sb = new StringBuilder(string);
+        int actualLength = length - 3;
+        if (sb.length() > actualLength) {
+            // -3 because we add 3 dots at the end. Returned string length has to be length including the dots.
+            if (!soft) {
+                return sb.insert(actualLength, "...").substring(0, actualLength + 3);
+            } else {
+                int endIndex = sb.indexOf(" ", actualLength);
+                if (endIndex == -1) {
+                    return string;
+                }
+                endIndex = endIndex >= sb.length() ? sb.length() : endIndex;
+                return sb.insert(endIndex, "...").substring(0, endIndex + 3);
+            }
+        }
+        return string;
+    }
 }


### PR DESCRIPTION
Signed-off-by: dasawanaka <michal.19.daniel.96@gmail.com>

Fixes #174 

Repaired all glitches in axiom renderen functions.

- [x] Repaired `LabelProvider` and `StringUtils` to generate fragment IRI using OWLApi functions instead of spliting and concating on string
- [x] Repaired numbering of elements in axioms, labels like 'label' now is numbering correctly in all cases
![repair-numer-of-elements](https://user-images.githubusercontent.com/26776168/157521774-f8300fdc-0e45-4043-b5ec-ecd7dc40bfd9.PNG)
- [x] Changing how to display `Range` and `Domain` to shorter version(removing subject and predicate), because name of `Range` and `Domain` is contained in header of group
![better-look-repair](https://user-images.githubusercontent.com/26776168/157524206-eedc732b-321c-45d2-94f3-3ede913f7f7e.PNG)
- [x]  I dont know why but some input iri's in `LabelProvider` has `<` on start and `>` on end. This is not correct. The iri/links with this error are provided by the backend, and the frontend does not deal with them, trying to create links to these invalid links. 
EDIT: Repaired in [9f8cb1a](https://github.com/edmcouncil/onto-viewer/pull/177/commits/9f8cb1af7d0dcb238dd26d2c4a199c061f447d51)
https://spec.edmcouncil.org/fibo/ontology?query=http%3A%2F%2Fwww.w3.org%2F2000%2F01%2Frdf-schema%23label 
```
{
    "type": "AXIOM",
    "value": "/arg6/ Domain /arg2/",
    "entityMaping": {
	    "/arg6/": {
		    "iri": "http://www.w3.org/2000/01/rdf-schema#label",
		    "label": "label"
	    },
	    "/arg2/": {
		    "iri": "<http://www.w3.org/2000/01/rdf-schema#Resource>",
		    "label": "Resource>"
	    }
    }
}
```
Tested on resource with IRI: http://www.w3.org/2000/01/rdf-schema#label

