### PR TITLE
222 OV updates its ontologies folder from a zip file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,6 +214,7 @@ catalog-v001.xml
 # Onto-Viewer
 docker/runtime/
 lucene_index/
+download/
 
 # Mac
 .DS_Store

--- a/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/loader/ConfigLoader.java
+++ b/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/loader/ConfigLoader.java
@@ -3,14 +3,21 @@ package org.edmcouncil.spec.ontoviewer.configloader.configuration.loader;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Arrays;
+
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
-import org.edmcouncil.spec.ontoviewer.configloader.configuration.loader.saxparser.ViewerCoreConfigurationHandler;
-import org.edmcouncil.spec.ontoviewer.configloader.configuration.model.CoreConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
+
+import org.edmcouncil.spec.ontoviewer.configloader.configuration.loader.saxparser.ViewerCoreConfigurationHandler;
+import org.edmcouncil.spec.ontoviewer.configloader.configuration.model.ConfigKeys;
+import org.edmcouncil.spec.ontoviewer.configloader.configuration.model.CoreConfiguration;
+import org.edmcouncil.spec.ontoviewer.configloader.configuration.model.impl.element.StringItem;
+import org.edmcouncil.spec.ontoviewer.configloader.configuration.properties.AppProperties;
+
 
 /**
  * @author Michał Daniel (michal.daniel@makolab.com)
@@ -19,13 +26,15 @@ public class ConfigLoader {
 
   private static final Logger LOG = LoggerFactory.getLogger(ConfigLoader.class);
 
+  final AppProperties appProperties;
   CoreConfiguration configuration;
-
-  public ConfigLoader() {
+  
+  public ConfigLoader(AppProperties appProperties) {
     this.configuration = new CoreConfiguration();
+    this.appProperties = appProperties;
   }
 
-  public void loadWeaselConfiguration(Path ontoViewerConfigurationPath) {
+  public void loadViewerConfiguration(Path ontoViewerConfigurationPath) {
     SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
     try {
       File configFile = ontoViewerConfigurationPath.toFile();
@@ -41,9 +50,29 @@ public class ConfigLoader {
     } catch (ParserConfigurationException | SAXException | IOException e) {
       LOG.error("Exception while loading configuration: {}", e.getMessage());
     }
+    
+    loadCommandLineConfigValues(); 
   }
 
   public CoreConfiguration getConfiguration() {
     return configuration;
+  }
+
+  private void loadCommandLineConfigValues() {
+    if(appProperties == null) return;
+    
+    String[] zipURL = appProperties.getZipURL();
+    if(zipURL != null && zipURL.length>0){
+      for (String url : Arrays.asList(zipURL)) {
+        configuration.addConfigElement(ConfigKeys.ONTOLOGY_ZIP_URL, new StringItem(url));
+      }
+    }
+    
+    String[] ontologyCatalogPaths = appProperties.getOntologyCatalogPaths();
+    if(ontologyCatalogPaths != null && ontologyCatalogPaths.length>0){
+      for (String path : Arrays.asList(ontologyCatalogPaths)) {
+        configuration.addConfigElement(ConfigKeys.ONTOLOGY_CATALOG_PATH, new StringItem(path));
+      }
+    }
   }
 }

--- a/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/loader/saxparser/ViewerCoreConfigurationHandler.java
+++ b/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/loader/saxparser/ViewerCoreConfigurationHandler.java
@@ -53,6 +53,12 @@ public class ViewerCoreConfigurationHandler extends DefaultHandler {
   @Override
   public void startElement(String uri, String localName, String qName, Attributes attributes) {
     switch (qName) {
+      case ConfigKeys.ONTOLOGY_ROOT:
+        int attributeLength = attributes.getLength();
+        if(attributeLength>0 && attributes.getQName(0).equals(ConfigKeys.ONTOLOGY_DOWNLOAD_DIR)) {
+          configuration.addConfigElement(ConfigKeys.ONTOLOGY_DOWNLOAD_DIR, new StringItem(attributes.getValue(0)));
+        }
+        break;
       case ConfigKeys.PRIORITY_LIST:
       case ConfigKeys.IGNORE_TO_DISPLAYING:
       case ConfigKeys.IGNORE_TO_LINKING:
@@ -63,6 +69,7 @@ public class ViewerCoreConfigurationHandler extends DefaultHandler {
       case ConfigKeys.ONTOLOGY_DIR:
       case ConfigKeys.ONTOLOGY_MAPPER:
       case ConfigKeys.ONTOLOGY_CATALOG_PATH:
+      case ConfigKeys.ONTOLOGY_ZIP_URL:
       case ConfigKeys.DISPLAY_LABEL:
       case ConfigKeys.FORCE_LABEL_LANG:
       case ConfigKeys.LABEL_LANG:
@@ -130,6 +137,7 @@ public class ViewerCoreConfigurationHandler extends DefaultHandler {
       case ConfigKeys.ONTOLOGY_MAPPER:
       case ConfigKeys.ONTOLOGY_CATALOG_PATH:
       case ConfigKeys.ONTOLOGY_MODULE_IGNORE_PATTERN:
+      case ConfigKeys.ONTOLOGY_ZIP_URL:
         StringItem ontologyPath = new StringItem(val);
         configuration.addConfigElement(key, ontologyPath);
         ontologyPath = null;

--- a/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/model/ConfigKeys.java
+++ b/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/model/ConfigKeys.java
@@ -5,6 +5,9 @@ package org.edmcouncil.spec.ontoviewer.configloader.configuration.model;
  * @author Patrycja Miazek (patrycja.miazek@makolab.com)
  */
 public class ConfigKeys {
+  
+  public static final String ONTOLOGY_ROOT = "ontology";
+  public static final String ONTOLOGY_DOWNLOAD_DIR = "ontologyDownloadDir";
 
   public static final String PRIORITY_LIST = "priorityList";
   public static final String PRIORITY_LIST_ELEMENT = "priority";
@@ -25,6 +28,7 @@ public class ConfigKeys {
   public static final String ONTOLOGY_MAPPER = "ontologyMapper";
   public static final String ONTOLOGY_MAPPING_MAP = "ontologyMapping";
   public static final String ONTOLOGY_CATALOG_PATH = "ontologyCatalogPath";
+  public static final String ONTOLOGY_ZIP_URL = "ontologyZipURL";
   //uri / iri
   public static final String SCOPE_IRI = "scopeIri";
   public static final String URI_NAMESPACE = "uriNamespace";

--- a/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/model/CoreConfiguration.java
+++ b/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/model/CoreConfiguration.java
@@ -120,7 +120,7 @@ public class CoreConfiguration implements Configuration<Set<ConfigItem>> {
 
   private void getOntologyDir(Map<String, Set<String>> result) {
     if (configuration.containsKey(ConfigKeys.ONTOLOGY_DIR)) {
-      Set<String> item = result.getOrDefault(ConfigKeys.ONTOLOGY_DIR, new HashSet<>());
+      Set<String> item = result.getOrDefault(ConfigKeys.ONTOLOGY_DIR, new LinkedHashSet<>());
       configuration.get(ConfigKeys.ONTOLOGY_DIR).forEach((configItem) -> {
         item.add(configItem.toString());
       });
@@ -136,6 +136,16 @@ public class CoreConfiguration implements Configuration<Set<ConfigItem>> {
       });
       result.put(ConfigKeys.ONTOLOGY_URL, item);
     }
+  }
+  
+  public  Set<String> getOntologyZipUrl() {
+    Set<String> result = new LinkedHashSet<>();
+    if (configuration.containsKey(ConfigKeys.ONTOLOGY_ZIP_URL)) {
+      configuration.get(ConfigKeys.ONTOLOGY_ZIP_URL).forEach((configItem) -> {
+        result.add(configItem.toString());
+      });
+    }
+    return result;
   }
 
   public Set<String> getOntologyMapper() {
@@ -355,5 +365,10 @@ public class CoreConfiguration implements Configuration<Set<ConfigItem>> {
         .map(StringItem.class::cast)
         .map(StringItem::toString)
         .collect(Collectors.toSet());
+  }
+  
+  public Optional<String> getOntologyDownloadDir() {
+    return getSingleStringValue(ConfigKeys.ONTOLOGY_DOWNLOAD_DIR);
+
   }
 }

--- a/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/model/CoreConfiguration.java
+++ b/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/model/CoreConfiguration.java
@@ -301,10 +301,9 @@ public class CoreConfiguration implements Configuration<Set<ConfigItem>> {
 
   public Optional<String> getSingleStringValue(String key) {
     var value = getValue(key);
-    if (value.isEmpty()) {
+    if (value == null || value.isEmpty()) {
       return Optional.empty();
     }
-
     return value.stream().map(Object::toString).findFirst();
   }
 

--- a/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/properties/AppProperties.java
+++ b/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/properties/AppProperties.java
@@ -18,6 +18,8 @@ public class AppProperties {
   private String viewerConfigFileName;
   private String defaultOntologyFileName;
   private String configPath;
+  private String[] zipURL;
+  private String[] ontologyCatalogPaths;
   private Map<String, Object> search;
 
   public String getConfigPath() {
@@ -59,4 +61,21 @@ public class AppProperties {
   public void setSearch(Map<String, Object> search) {
     this.search = search;
   }
+
+  public String[] getZipURL() {
+    return zipURL;
+  }
+
+  public void setZipURL(String[] ZipURL) {
+    this.zipURL = ZipURL;
+  }
+
+  public String[] getOntologyCatalogPaths() {
+    return ontologyCatalogPaths;
+  }
+
+  public void setOntologyCatalogPaths(String[] ontologyCatalogPaths) {
+    this.ontologyCatalogPaths = ontologyCatalogPaths;
+  }
+ 
 }

--- a/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/service/FileBasedConfigurationService.java
+++ b/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/service/FileBasedConfigurationService.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
 import org.edmcouncil.spec.ontoviewer.configloader.configuration.loader.ConfigLoader;
 import org.edmcouncil.spec.ontoviewer.configloader.configuration.model.CoreConfiguration;
+import org.edmcouncil.spec.ontoviewer.configloader.configuration.properties.AppProperties;
 import org.edmcouncil.spec.ontoviewer.configloader.utils.files.FileSystemManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,18 +16,20 @@ public class FileBasedConfigurationService implements ConfigurationService {
   private static final Logger LOGGER = LoggerFactory.getLogger(FileBasedConfigurationService.class);
 
   private final FileSystemManager fileSystemManager;
+  private final AppProperties appProperties;
 
   private CoreConfiguration coreConfiguration;
 
-  public FileBasedConfigurationService(FileSystemManager fileSystemManager) {
+  public FileBasedConfigurationService(FileSystemManager fileSystemManager, AppProperties appProperties) {
     this.fileSystemManager = fileSystemManager;
+    this.appProperties = appProperties;
   }
 
   @PostConstruct
   public void init() {
     LOGGER.debug("Loading configuration...");
 
-    var configLoader = new ConfigLoader();
+    var configLoader = new ConfigLoader(appProperties);
 
     try {
       var configFilePath = fileSystemManager.getPathToConfigFile();
@@ -41,7 +44,7 @@ public class FileBasedConfigurationService implements ConfigurationService {
         for (var path : paths.collect(Collectors.toList())) {
           LOGGER.debug("Adding configuration from file '{}'.", path);
           if (Files.isRegularFile(path)) {
-            configLoader.loadWeaselConfiguration(path);
+            configLoader.loadViewerConfiguration(path);
           }
         }
       }

--- a/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/utils/files/FileSystemManager.java
+++ b/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/utils/files/FileSystemManager.java
@@ -75,7 +75,7 @@ public class FileSystemManager {
     return createDirIfNotExists(homeDir).resolve(defaultOntologyFileName);
   }
 
-  public Path getPathToOntologyFile(String pathString) throws IOException {
+  public Path getPathToFile(String pathString) throws IOException {
     var path = Paths.get(pathString);
     if (path.isAbsolute()) {
       return path;
@@ -100,7 +100,4 @@ public class FileSystemManager {
     return getViewerHomeDir().resolve("api.key");
   }
 
-  public Path getPathToUpdateHistory() {
-    return getViewerHomeDir().resolve("updateHistory.json");
-  }
 }

--- a/onto-viewer-config-loader/src/test/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/loader/ConfigLoaderTest.java
+++ b/onto-viewer-config-loader/src/test/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/loader/ConfigLoaderTest.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import org.edmcouncil.spec.ontoviewer.configloader.configuration.properties.AppProperties;
 
 /**
  * @author Patrycja Miazek (patrycja.miazek@makolab.com)
@@ -50,11 +51,11 @@ class ConfigLoaderTest {
       prepareConfigFiles(configFileName);
     }
 
-    var configLoader = new ConfigLoader();
+    var configLoader = new ConfigLoader(new AppProperties());
     try {
       Files.list(tempDir)
           .filter(Files::isRegularFile)
-          .forEach(configLoader::loadWeaselConfiguration);
+          .forEach(configLoader::loadViewerConfiguration);
 
       this.testViewerCoreConfig = configLoader.getConfiguration();
     } catch (Exception e) {

--- a/onto-viewer-core/pom.xml
+++ b/onto-viewer-core/pom.xml
@@ -86,5 +86,10 @@
       <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>net.lingala.zip4j</groupId>
+      <artifactId>zip4j</artifactId>
+      <version>2.10.0</version>
+    </dependency>
   </dependencies>
 </project>

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/OwlDataHandler.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/OwlDataHandler.java
@@ -565,9 +565,9 @@ public class OwlDataHandler {
       boolean bypassClass
   ) {
     String value = rendering.render(axiom);
-    LOG.debug("Rendered default value: {}", value);
+    LOG.info("Rendered default value: {}", value);
     for (String unwantedType : unwantedTypes) {
-      value = value.replace(unwantedType, "");
+      value = value.replaceAll(unwantedType, "");
     }
 
     if (bypassClass) {

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/loader/AutoOntologyLoader.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/loader/AutoOntologyLoader.java
@@ -16,17 +16,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import org.apache.commons.io.FilenameUtils;
-import org.edmcouncil.spec.ontoviewer.configloader.configuration.model.ConfigKeys;
-import org.edmcouncil.spec.ontoviewer.configloader.configuration.model.CoreConfiguration;
-import org.edmcouncil.spec.ontoviewer.configloader.utils.files.FileSystemManager;
-import org.edmcouncil.spec.ontoviewer.core.exception.OntoViewerException;
-import org.edmcouncil.spec.ontoviewer.core.mapping.OntologyCatalogParser;
-import org.edmcouncil.spec.ontoviewer.core.mapping.model.Uri;
-import org.edmcouncil.spec.ontoviewer.core.ontology.loader.OntologyMapping.MappingSource;
-import org.edmcouncil.spec.ontoviewer.core.ontology.loader.OntologySource.SourceType;
-import org.edmcouncil.spec.ontoviewer.core.ontology.loader.listener.MissingImportListenerImpl;
-import org.edmcouncil.spec.ontoviewer.core.utils.PathUtils;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.AddImport;
 import org.semanticweb.owlapi.model.IRI;
@@ -39,6 +30,18 @@ import org.semanticweb.owlapi.model.OWLOntologyLoaderConfiguration;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.util.SimpleIRIMapper;
 import org.slf4j.Logger;
+
+import org.edmcouncil.spec.ontoviewer.configloader.configuration.model.ConfigKeys;
+import org.edmcouncil.spec.ontoviewer.configloader.configuration.model.CoreConfiguration;
+import org.edmcouncil.spec.ontoviewer.configloader.utils.files.FileSystemManager;
+import org.edmcouncil.spec.ontoviewer.core.exception.OntoViewerException;
+import org.edmcouncil.spec.ontoviewer.core.mapping.OntologyCatalogParser;
+import org.edmcouncil.spec.ontoviewer.core.mapping.model.Uri;
+import org.edmcouncil.spec.ontoviewer.core.ontology.loader.OntologyMapping.MappingSource;
+import org.edmcouncil.spec.ontoviewer.core.ontology.loader.OntologySource.SourceType;
+import org.edmcouncil.spec.ontoviewer.core.ontology.loader.listener.MissingImportListenerImpl;
+import org.edmcouncil.spec.ontoviewer.core.utils.PathUtils;
+
 
 /**
  * @author Patrycja Miazek (patrycja.miazek@makolab.com)
@@ -253,7 +256,7 @@ public class AutoOntologyLoader {
         ontologyLoadingProblems.add(new OntologyLoadingProblem(ontologySource, ex.getMessage(), ex.getClass()));
       }
     }
-    LOGGER.info("Missing imports: {}", missingImportListenerImpl.getNotImportUri());
+
     LOGGER.info("Ontology loading problems that occurred: {}", ontologyLoadingProblems);
     return umbrellaOntology;
   }

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/loader/CommandLineOntologyLoader.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/loader/CommandLineOntologyLoader.java
@@ -10,7 +10,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.edmcouncil.spec.ontoviewer.configloader.configuration.model.ConfigKeys;
 import org.edmcouncil.spec.ontoviewer.configloader.configuration.model.CoreConfiguration;
+import org.edmcouncil.spec.ontoviewer.configloader.utils.files.FileSystemManager;
+import org.edmcouncil.spec.ontoviewer.core.ontology.loader.listener.MissingImport;
 import org.edmcouncil.spec.ontoviewer.core.ontology.loader.listener.MissingImportListenerImpl;
+import org.edmcouncil.spec.ontoviewer.core.ontology.loader.zip.ViewerZipFilesOperations;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.AddImport;
 import org.semanticweb.owlapi.model.IRI;
@@ -31,13 +34,20 @@ public class CommandLineOntologyLoader {
 
   private final CoreConfiguration coreConfiguration;
   private final MissingImportListenerImpl missingImportListenerImpl;
+  private final FileSystemManager fileSystemManager;
 
-  public CommandLineOntologyLoader(CoreConfiguration coreConfiguration) {
+  public CommandLineOntologyLoader(CoreConfiguration coreConfiguration, FileSystemManager fileSystemManager) {
     this.coreConfiguration = coreConfiguration;
     this.missingImportListenerImpl = new MissingImportListenerImpl();
+    this.fileSystemManager = fileSystemManager;
   }
 
   public OWLOntology load() throws OWLOntologyCreationException {
+    
+    ViewerZipFilesOperations viewerZipFilesOperations = new ViewerZipFilesOperations();
+    Set<MissingImport> missingImports = viewerZipFilesOperations.prepareZipToLoad(coreConfiguration, fileSystemManager);
+    this.missingImportListenerImpl.addAll(missingImports);
+    
     var owlOntologyManager = OWLManager.createOWLOntologyManager();
 
     setOntologyMapping(owlOntologyManager);

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/loader/listener/MissingImportListenerImpl.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/loader/listener/MissingImportListenerImpl.java
@@ -26,4 +26,8 @@ public class MissingImportListenerImpl implements MissingImportListener {
   public Set<MissingImport> getNotImportUri() {
     return missingImports;
   }
+  
+  public void addAll(Set<MissingImport> missingImports){
+    this.missingImports.addAll(missingImports);
+  }
 }

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/loader/zip/ViewerZipFilesOperations.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/loader/zip/ViewerZipFilesOperations.java
@@ -1,0 +1,115 @@
+package org.edmcouncil.spec.ontoviewer.core.ontology.loader.zip;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import net.lingala.zip4j.ZipFile;
+import net.lingala.zip4j.exception.ZipException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.apache.commons.io.FileUtils; 
+import org.edmcouncil.spec.ontoviewer.configloader.configuration.model.CoreConfiguration;
+
+import org.edmcouncil.spec.ontoviewer.configloader.utils.files.FileSystemManager;
+import org.edmcouncil.spec.ontoviewer.core.ontology.loader.listener.MissingImport;
+
+
+/**
+ *
+ * @author Michal Daniel(michal.daniel@makolab.com)
+ */
+public class ViewerZipFilesOperations {
+  
+  private static final Logger LOGGER = LoggerFactory.getLogger(ViewerZipFilesOperations.class);
+  
+  public Set<MissingImport> prepareZipToLoad(CoreConfiguration config, FileSystemManager fileSystemManager) {
+    Set<MissingImport> missingImports = new LinkedHashSet<>();
+    LOGGER.trace("Ontology ZIP URLS : {}", config.getOntologyZipUrl());
+    LOGGER.trace("Ontology Download Dir : {}", config.getOntologyDownloadDir());
+    //checking if zip files can be downloaded at all
+    if(!config.getOntologyZipUrl().isEmpty()
+        && config.getOntologyDownloadDir().isPresent()){
+      Path downloadDir = null;
+      try {
+        downloadDir = fileSystemManager.getPathToFile(config.getOntologyDownloadDir().get());
+      } catch (IOException e) {
+        LOGGER.error(e.toString());
+        MissingImport missingImport = new MissingImport();
+        missingImport.setIri(config.getOntologyDownloadDir().get());
+        missingImport.setCause(e.toString());
+        missingImports.add(missingImport);
+      }
+      
+      if(downloadDir != null && downloadDir.toFile().exists() && downloadDir.toFile().isDirectory()){
+        try {
+          clearDirectory(downloadDir.toFile());
+        } catch (IOException ex) {
+          LOGGER.error(ex.toString());
+        }
+        
+        for (String fileUrl : config.getOntologyZipUrl()) {
+          File downloadedFile = null;
+          try {
+            downloadedFile = downloadFileFromUrlToDir(fileUrl, downloadDir);
+          } catch (IOException ex) {
+            LOGGER.error(ex.toString());
+            MissingImport missingImport = new MissingImport();
+            missingImport.setIri(config.getOntologyDownloadDir().get());
+            missingImport.setCause(ex.toString());
+            missingImports.add(missingImport);
+          }
+          if(downloadedFile != null){
+            try {
+              unzipFolder(downloadedFile.toPath(), downloadDir);
+            } catch (ZipException ex) {
+              LOGGER.error(ex.toString());
+              MissingImport missingImport = new MissingImport();
+              missingImport.setIri(downloadedFile.toPath().toString());
+              missingImport.setCause(ex.toString());
+              missingImports.add(missingImport);
+            }
+            if(!downloadedFile.delete()){
+              LOGGER.error("Can not delete file: {}", downloadedFile.toPath().toString());
+            }
+          }
+        }
+        
+      } else {
+        MissingImport missingImport = new MissingImport();
+        missingImport.setIri(downloadDir.toString());
+        missingImport.setCause("Download directory not exists or it's not 'directory'");
+        missingImports.add(missingImport);
+      }
+    }
+    return missingImports;
+  }
+  
+  private File downloadFileFromUrlToDir(String fileUrl, Path downloadDir) throws MalformedURLException, IOException{
+    File outputFile = downloadDir
+      .resolve(fileUrl.substring(fileUrl.lastIndexOf("/")+1))
+      .toFile();
+    FileUtils.copyURLToFile(new URL(fileUrl), outputFile);
+    return outputFile;
+  }
+  
+  private void unzipFolder(Path source, Path target) throws ZipException{
+    new ZipFile(source.toFile())
+                .extractAll(target.toString());
+  }
+
+  private void clearDirectory(File downloadDir) throws IOException {
+    File[] allContents = downloadDir.listFiles();
+    if (allContents != null) {
+        for (File file : allContents) {
+          if(file.isDirectory())
+            FileUtils.deleteDirectory(file);
+          file.delete();
+        }
+    }
+  }
+}

--- a/onto-viewer-toolkit/src/main/java/org/edmcouncil/spec/ontoviewer/toolkit/config/ApplicationConfiguration.java
+++ b/onto-viewer-toolkit/src/main/java/org/edmcouncil/spec/ontoviewer/toolkit/config/ApplicationConfiguration.java
@@ -9,7 +9,7 @@ import org.edmcouncil.spec.ontoviewer.core.ontology.data.RestrictionGraphDataHan
 import org.edmcouncil.spec.ontoviewer.core.ontology.data.extractor.OwlDataExtractor;
 import org.edmcouncil.spec.ontoviewer.core.ontology.data.handler.AnnotationsDataHandler;
 import org.edmcouncil.spec.ontoviewer.core.ontology.data.handler.IndividualDataHandler;
-import org.edmcouncil.spec.ontoviewer.core.ontology.data.handler.fibo.FiboDataHandler;
+import org.edmcouncil.spec.ontoviewer.core.ontology.data.handler.DataHandler;
 import org.edmcouncil.spec.ontoviewer.core.ontology.data.label.LabelProvider;
 import org.edmcouncil.spec.ontoviewer.core.ontology.factory.CustomDataFactory;
 import org.springframework.context.annotation.Bean;
@@ -24,7 +24,7 @@ import org.springframework.core.io.ClassPathResource;
     AnnotationsDataHandler.class,
     CustomDataFactory.class,
     DetailsManager.class,
-    FiboDataHandler.class,
+    DataHandler.class,
     IndividualDataHandler.class,
     LabelProvider.class,
     OntologyManager.class,

--- a/onto-viewer-web-app/config/ontology_config.xml
+++ b/onto-viewer-web-app/config/ontology_config.xml
@@ -7,9 +7,9 @@
   <!-- Loading sequence paths => urls => directories -->
   <ontology  ontologyDownloadDir="download">
  
-    <!--<ontologyURL>https://spec.edmcouncil.org/fibo/ontology/MetadataFIBO/</ontologyURL>
-    <ontologyURL>https://spec.edmcouncil.org/fibo/ontology/AboutFIBODev/</ontologyURL>-->
-    <ontologyURL>https://spec.edmcouncil.org/auto/ontology/AboutAUTODev/</ontologyURL>
+    <ontologyURL>https://spec.edmcouncil.org/fibo/ontology/MetadataFIBO/</ontologyURL>
+    <ontologyURL>https://spec.edmcouncil.org/fibo/ontology/AboutFIBODev/</ontologyURL>
+    <!--<ontologyURL>https://spec.edmcouncil.org/auto/ontology/AboutAUTODev/</ontologyURL>-->
     <!--<ontologyZipURL>https://spec.edmcouncil.org/fibo/ontology/master/latest/dev.rdf.zip</ontologyZipURL>-->
    
     <!-- order in this file gives the correct loading order -->

--- a/onto-viewer-web-app/config/ontology_config.xml
+++ b/onto-viewer-web-app/config/ontology_config.xml
@@ -4,14 +4,19 @@
   <!-- To load an ontology from the internet, enter the URL between the <ontologyURL> tags -->
   <!-- To load an ontology from a folder, enter the path address with application between <ontologyPath> tags or enter the file name  -->
   <!-- If no URL or path is provided, the program will load the ontology from the default folder -->
-  <ontology>
+  <!-- Loading sequence paths => urls => directories -->
+  <ontology  ontologyDownloadDir="download">
  
-    <ontologyURL>https://spec.edmcouncil.org/fibo/ontology/MetadataFIBO/</ontologyURL>
-    <ontologyURL>https://spec.edmcouncil.org/fibo/ontology/AboutFIBODev/</ontologyURL>
-    <!--<ontologyURL>https://spec.edmcouncil.org/auto/ontology/AboutAUTODev/</ontologyURL>-->
+    <!--<ontologyURL>https://spec.edmcouncil.org/fibo/ontology/MetadataFIBO/</ontologyURL>
+    <ontologyURL>https://spec.edmcouncil.org/fibo/ontology/AboutFIBODev/</ontologyURL>-->
+    <ontologyURL>https://spec.edmcouncil.org/auto/ontology/AboutAUTODev/</ontologyURL>
+    <!--<ontologyZipURL>https://spec.edmcouncil.org/fibo/ontology/master/latest/dev.rdf.zip</ontologyZipURL>-->
+   
+    <!-- order in this file gives the correct loading order -->
     <ontologyDir>ontologies</ontologyDir>
     <ontologyDir>staticOntologies</ontologyDir>
-    <ontologyMapper>fiboMapper</ontologyMapper>
+    <ontologyDir>download</ontologyDir>
+    
     <ontologyCatalogPath>ontologies/catalog-v001.xml</ontologyCatalogPath>
   </ontology>
 

--- a/onto-viewer-web-app/fiboMapper/README
+++ b/onto-viewer-web-app/fiboMapper/README
@@ -1,1 +1,0 @@
-Download and unzip from https://spec.edmcouncil.org/fibo/ontology/master/latest/dev.rdf.zip

--- a/onto-viewer-web-app/src/main/java/org/edmcouncil/spec/ontoviewer/webapp/boot/UpdaterThread.java
+++ b/onto-viewer-web-app/src/main/java/org/edmcouncil/spec/ontoviewer/webapp/boot/UpdaterThread.java
@@ -1,8 +1,17 @@
 package org.edmcouncil.spec.ontoviewer.webapp.boot;
 
+import org.edmcouncil.spec.ontoviewer.core.ontology.loader.zip.ViewerZipFilesOperations;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+import org.semanticweb.owlapi.model.UnloadableImportException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.edmcouncil.spec.ontoviewer.configloader.configuration.model.CoreConfiguration;
 import org.edmcouncil.spec.ontoviewer.configloader.configuration.service.ConfigurationService;
 import org.edmcouncil.spec.ontoviewer.configloader.utils.files.FileSystemManager;
@@ -20,16 +29,10 @@ import org.edmcouncil.spec.ontoviewer.core.ontology.updater.model.UpdateJob;
 import org.edmcouncil.spec.ontoviewer.core.ontology.updater.model.UpdateJobStatus;
 import org.edmcouncil.spec.ontoviewer.core.ontology.updater.util.UpdaterOperation;
 import org.edmcouncil.spec.ontoviewer.webapp.search.LuceneSearcher;
-import org.semanticweb.owlapi.model.IRI;
-import org.semanticweb.owlapi.model.OWLOntology;
-import org.semanticweb.owlapi.model.OWLOntologyCreationException;
-import org.semanticweb.owlapi.model.UnloadableImportException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public abstract class UpdaterThread extends Thread implements Thread.UncaughtExceptionHandler {
 
-  private static final Logger LOG = LoggerFactory.getLogger(UpdaterThread.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(UpdaterThread.class);
   private static final String interruptMessage = "Interrupts this update. New update request.";
 
   private ConfigurationService config;
@@ -77,7 +80,7 @@ public abstract class UpdaterThread extends Thread implements Thread.UncaughtExc
           String msg = String.format("UpdateJob with id: %s waiting to end other updates",
               job.getId());
           UpdaterOperation.setJobStatusToWaiting(job, msg);
-          LOG.debug(msg);
+          LOGGER.debug(msg);
           //Wait for one sec so it doesn't print too fast
           Thread.sleep(1000);
         } catch (InterruptedException e) {
@@ -102,16 +105,18 @@ public abstract class UpdaterThread extends Thread implements Thread.UncaughtExc
       Map<IRI, IRI> iriToPathMapping = new HashMap<>();
       String msgError = null;
 
-      LOG.info("Configuration loaded ? : {}", config != null || !config.getCoreConfiguration().isEmpty());
-      LOG.info("File system manager created ? : {}", fileSystemManager != null);
+      LOGGER.info("Configuration loaded ? : {}", config != null || !config.getCoreConfiguration().isEmpty());
+      LOGGER.info("File system manager created ? : {}", fileSystemManager != null);
 
       CoreConfiguration viewerCoreConfiguration = config.getCoreConfiguration();
 
       if (isInterrupt()) {
         throw new InterruptUpdate();
       }
+      //ZIP Support 
+      ViewerZipFilesOperations viewerZipFilesOperations = new ViewerZipFilesOperations();
+      Set<MissingImport> missingImports = viewerZipFilesOperations.prepareZipToLoad(viewerCoreConfiguration, fileSystemManager);
 
-      //download ontology file/files
       //load ontology to var
       AutoOntologyLoader loader = new AutoOntologyLoader(viewerCoreConfiguration, fileSystemManager);
       try {
@@ -120,13 +125,13 @@ public abstract class UpdaterThread extends Thread implements Thread.UncaughtExc
         iriToPathMapping = loadedOntologyData.getIriToPathMapping();
       } catch (OWLOntologyCreationException ex) {
         msgError = ex.getMessage();
-        LOG.error(
+        LOGGER.error(
             "[ERROR]: Error when creating ontology. Stopping application. Exception: {} \n Message: {}",
             ex.getStackTrace(), ex.getMessage());
       }
 
       if (msgError != null) {
-        LOG.error("[ERROR]: Cannot update, id {}", job.getId());
+        LOGGER.error("[ERROR]: Cannot update, id {}", job.getId());
         job = UpdaterOperation.setJobStatusToError(job, msgError);
         blocker.setUpdateNow(Boolean.FALSE);
         return;
@@ -135,8 +140,8 @@ public abstract class UpdaterThread extends Thread implements Thread.UncaughtExc
         throw new InterruptUpdate();
       }
 
-      Set<MissingImport> missingImports = loader.getMissingImportListenerImpl().getNotImportUri();
-
+      missingImports.addAll(loader.getMissingImportListenerImpl().getNotImportUri());
+      LOGGER.info("Missing imports: {}", missingImports);
       Set<String> scopes = scopeIriOntology.getScopeIri(ontology);
 
       if (isInterrupt()) {
@@ -176,9 +181,9 @@ public abstract class UpdaterThread extends Thread implements Thread.UncaughtExc
         blocker.setInitializeAppDone(Boolean.TRUE);
       }
 
-      LOG.info("Application has started successfully.");
+      LOGGER.info("Application has started successfully.");
     } catch (InterruptUpdate ex) {
-      LOG.error("{}", ex.getStackTrace());
+      LOGGER.error("{}", ex.getStackTrace());
       UpdaterOperation.setJobStatusToError(job, interruptMessage);
       blocker.setUpdateNow(Boolean.FALSE);
       this.interrupt();
@@ -188,14 +193,14 @@ public abstract class UpdaterThread extends Thread implements Thread.UncaughtExc
       UpdaterOperation.setJobStatusToError(job, ex.getMessage());
       blocker.setUpdateNow(Boolean.FALSE);
       this.interrupt();
-    }
+    } 
   }
 
   @Override
   public void uncaughtException(Thread t, Throwable e) {
 
     UpdaterOperation.setJobStatusToError(job, e.getMessage());
-    LOG.error(e.getStackTrace().toString());
+    LOGGER.error(e.getStackTrace().toString());
     blocker.setUpdateNow(Boolean.FALSE);
   }
 

--- a/onto-viewer-web-app/src/main/java/org/edmcouncil/spec/ontoviewer/webapp/boot/UpdaterThread.java
+++ b/onto-viewer-web-app/src/main/java/org/edmcouncil/spec/ontoviewer/webapp/boot/UpdaterThread.java
@@ -1,6 +1,5 @@
 package org.edmcouncil.spec.ontoviewer.webapp.boot;
 
-import org.edmcouncil.spec.ontoviewer.core.ontology.loader.zip.ViewerZipFilesOperations;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -29,6 +28,7 @@ import org.edmcouncil.spec.ontoviewer.core.ontology.updater.model.UpdateJob;
 import org.edmcouncil.spec.ontoviewer.core.ontology.updater.model.UpdateJobStatus;
 import org.edmcouncil.spec.ontoviewer.core.ontology.updater.util.UpdaterOperation;
 import org.edmcouncil.spec.ontoviewer.webapp.search.LuceneSearcher;
+import org.edmcouncil.spec.ontoviewer.core.ontology.loader.zip.ViewerZipFilesOperations;
 
 public abstract class UpdaterThread extends Thread implements Thread.UncaughtExceptionHandler {
 

--- a/onto-viewer-web-app/src/main/java/org/edmcouncil/spec/ontoviewer/webapp/configuration/ApplicationConfiguration.java
+++ b/onto-viewer-web-app/src/main/java/org/edmcouncil/spec/ontoviewer/webapp/configuration/ApplicationConfiguration.java
@@ -1,5 +1,6 @@
 package org.edmcouncil.spec.ontoviewer.webapp.configuration;
 
+import org.edmcouncil.spec.ontoviewer.configloader.configuration.properties.AppProperties;
 import org.edmcouncil.spec.ontoviewer.configloader.configuration.service.ConfigurationService;
 import org.edmcouncil.spec.ontoviewer.configloader.configuration.service.FileBasedConfigurationService;
 import org.edmcouncil.spec.ontoviewer.configloader.utils.files.FileSystemManager;
@@ -10,13 +11,15 @@ import org.springframework.context.annotation.Configuration;
 public class ApplicationConfiguration {
 
   private final FileSystemManager fileSystemManager;
+  private final AppProperties appProperties;
 
-  public ApplicationConfiguration(FileSystemManager fileSystemManager) {
+  public ApplicationConfiguration(FileSystemManager fileSystemManager, AppProperties appProperties) {
     this.fileSystemManager = fileSystemManager;
+    this.appProperties = appProperties;
   }
 
   @Bean
   public ConfigurationService getConfigurationService() {
-    return new FileBasedConfigurationService(fileSystemManager);
+    return new FileBasedConfigurationService(fileSystemManager, appProperties);
   }
 }

--- a/onto-viewer-web-app/src/main/resources/application.properties
+++ b/onto-viewer-web-app/src/main/resources/application.properties
@@ -28,3 +28,6 @@ logging.level.org.edmcouncil.spec.ontoviewer=INFO
 # Search defaults
 app.search.reindexOnStart=true
 app.search.fuzzyDistance=3
+
+app.zipURL=
+app.OntologyCatalogPaths=


### PR DESCRIPTION
OV updates its ontologies folder from a zip file:
- [x]  config file 
- [x]  command line - multiple values (delimiter `,`)

Ontology catalog path(`catalog-v001.xml`): 
- [x]  command line - multiple values (delimiter `,`)

OV toolkit:
- [x]  load ontologies

To add from the command line use `-DzipURL=values` for urls to zip file and `-DontologyCatalogPaths=values`

Signed-off-by: dasawanaka <michal.19.daniel.96@gmail.com>

Fixes #222 
