### PR TITLE
222 - Merge develop into 222-ov-updates-its-ontologies-folder-from-a-zip-file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,6 +214,7 @@ catalog-v001.xml
 # Onto-Viewer
 docker/runtime/
 lucene_index/
+download/
 
 # Mac
 .DS_Store

--- a/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/model/ConfigurationData.java
+++ b/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/model/ConfigurationData.java
@@ -181,10 +181,14 @@ public class ConfigurationData {
     private final List<String> moduleToIgnore;
     private final Map<String, String> ontologyMappings;
     private boolean automaticCreationOfModules;
+    private final List<String> downloadDirectory;
+    private final List<String> zipUrls;
 
     public OntologiesConfig(List<String> urls,
         List<String> paths,
         List<String> catalogPaths,
+        List<String> downloadDirectory,
+        List<String> zipUrls,
         List<String> moduleIgnorePatterns,
         List<String> moduleToIgnore,
         boolean automaticCreationOfModules ) {
@@ -195,6 +199,8 @@ public class ConfigurationData {
       this.moduleToIgnore = moduleToIgnore;
       this.ontologyMappings = new HashMap<>();
       this.automaticCreationOfModules = automaticCreationOfModules;
+      this.downloadDirectory = downloadDirectory;
+      this.zipUrls = zipUrls;
     }
 
     public List<String> getUrls() {
@@ -227,6 +233,14 @@ public class ConfigurationData {
 
     public void setAutomaticCreationOfModules(boolean automaticCreationOfModules) {
       this.automaticCreationOfModules = automaticCreationOfModules;
+    }
+
+    public List<String> getDownloadDirectory() {
+        return downloadDirectory;
+    }
+
+    public List<String> getZipUrls() {
+        return zipUrls;
     }
   }
 

--- a/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/model/ConfigurationKey.java
+++ b/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/model/ConfigurationKey.java
@@ -34,6 +34,8 @@ public enum ConfigurationKey {
   SOURCE("source"),
   PATH("path"),
   URL("url"),
+  ZIP("zip"),
+  DOWNLOAD_DIRECTORY("download_directory"),
   CATALOG_PATH("catalog_path"),
   MODULE_IGNORE_PATTERN("module_ignore_pattern"),
   MODULE_TO_IGNORE("module_to_ignore"),

--- a/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/service/AbstractYamlConfigurationService.java
+++ b/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/service/AbstractYamlConfigurationService.java
@@ -24,6 +24,7 @@ import static org.edmcouncil.spec.ontoviewer.configloader.configuration.model.Co
 import static org.edmcouncil.spec.ontoviewer.configloader.configuration.model.ConfigurationKey.SOURCE;
 import static org.edmcouncil.spec.ontoviewer.configloader.configuration.model.ConfigurationKey.USER_DEFAULT_NAME_LIST;
 import static org.edmcouncil.spec.ontoviewer.configloader.configuration.model.ConfigurationKey.byName;
+import static org.edmcouncil.spec.ontoviewer.configloader.configuration.model.ConfigurationKey.DOWNLOAD_DIRECTORY;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -209,6 +210,7 @@ public abstract class AbstractYamlConfigurationService implements ApplicationCon
   protected OntologiesConfig handleOntologies(Map<String, Object> ontologies) {
     List<String> urls = new ArrayList<>();
     List<String> paths = new ArrayList<>();
+    List<String> zips = new ArrayList<>();
 
     @SuppressWarnings("unchecked")
     var sources = (List<Map<String, String>>) ontologies.get(SOURCE.getLabel());
@@ -221,6 +223,8 @@ public abstract class AbstractYamlConfigurationService implements ApplicationCon
             paths.add(sourceEntry.getValue());
           } else if (sourceEntryKey.equals(ConfigurationKey.URL.getLabel())) {
             urls.add(sourceEntry.getValue());
+          } else if (sourceEntryKey.equals(ConfigurationKey.ZIP.getLabel())) {
+            zips.add(sourceEntry.getValue());
           } else {
             LOGGER.warn("Unknown key '{}' with value '{}' in the ontologies source configuration.",
                 sourceEntry.getKey(), sourceEntry.getValue());
@@ -234,8 +238,9 @@ public abstract class AbstractYamlConfigurationService implements ApplicationCon
     List<String> moduleToIgnore = getListOfStringsFromObject(ontologies.get(MODULE_TO_IGNORE.getLabel()));
     boolean automaticCreationOfModules = 
         getBooleanFromObject(ontologies.get(AUTOMATIC_CREATION_OF_MODULES.getLabel()), AUTOMATIC_CREATION_OF_MODULES_DEFULT);
-
-    return new OntologiesConfig(urls, paths, catalogPaths, moduleIgnorePatterns, moduleToIgnore, automaticCreationOfModules);
+     List<String> downloadDirectory = getListOfStringsFromObject(ontologies.get(DOWNLOAD_DIRECTORY.getLabel()));
+    
+    return new OntologiesConfig(urls, paths, catalogPaths, downloadDirectory, zips, moduleIgnorePatterns, moduleToIgnore, automaticCreationOfModules);
   }
 
   protected Map<String, List<String>> mapToMapOfList(List<?> rawGroupsList) {

--- a/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/service/YamlFileBasedConfigurationService.java
+++ b/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/service/YamlFileBasedConfigurationService.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -34,6 +35,10 @@ public class YamlFileBasedConfigurationService extends AbstractYamlConfiguration
 
   @Value("${app.config.ontologies.catalog_path:}")
   private String catalogPath;
+  @Value("${app.config.ontologies.download_directory:}")
+  private String downloadDirectory;
+  @Value("${app.config.ontologies.zip_url:}")
+  private String[] zipUrl;
   private ConfigurationData configurationData;
 
   public YamlFileBasedConfigurationService(FileSystemManager fileSystemManager) {
@@ -127,6 +132,14 @@ public class YamlFileBasedConfigurationService extends AbstractYamlConfiguration
             if (catalogPath != null && !catalogPath.isBlank()) {
               ontologiesConfig.getCatalogPaths().clear();
               ontologiesConfig.getCatalogPaths().add(catalogPath);
+            }
+            if (downloadDirectory != null && !downloadDirectory.isBlank()) {
+              ontologiesConfig.getDownloadDirectory().clear();
+              ontologiesConfig.getDownloadDirectory().add(downloadDirectory);
+            }
+            if (zipUrl != null && zipUrl.length>0) {
+              ontologiesConfig.getZipUrls().clear();
+              ontologiesConfig.getZipUrls().addAll(Arrays.asList(zipUrl));
             }
             break;
           }

--- a/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/utils/files/FileSystemManager.java
+++ b/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/utils/files/FileSystemManager.java
@@ -75,7 +75,7 @@ public class FileSystemManager {
     return createDirIfNotExists(homeDir).resolve(defaultOntologyFileName);
   }
 
-  public Path getPathToOntologyFile(String pathString) throws IOException {
+  public Path getPathToFile(String pathString) throws IOException {
     var path = Paths.get(pathString);
     if (path.isAbsolute()) {
       return path;
@@ -100,7 +100,4 @@ public class FileSystemManager {
     return getViewerHomeDir().resolve("api.key");
   }
 
-  public Path getPathToUpdateHistory() {
-    return getViewerHomeDir().resolve("updateHistory.json");
-  }
 }

--- a/onto-viewer-core/pom.xml
+++ b/onto-viewer-core/pom.xml
@@ -62,6 +62,11 @@
       <artifactId>simple-xml</artifactId>
       <version>${simple-xml.version}</version>
     </dependency>
+    <dependency>
+      <groupId>net.lingala.zip4j</groupId>
+      <artifactId>zip4j</artifactId>
+      <version>2.10.0</version>
+    </dependency>
     <!-- Testing -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/OwlDataHandler.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/OwlDataHandler.java
@@ -563,7 +563,7 @@ public class OwlDataHandler {
     String value = rendering.render(axiom);
     LOG.debug("Rendered default value: {}", value);
     for (String unwantedType : unwantedTypes) {
-      value = value.replace(unwantedType, "");
+      value = value.replaceAll(unwantedType, "");
     }
 
     if (bypassClass) {

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/loader/AutoOntologyLoader.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/loader/AutoOntologyLoader.java
@@ -224,7 +224,6 @@ public class AutoOntologyLoader {
         ontologyLoadingProblems.add(new OntologyLoadingProblem(ontologySource, ex.getMessage(), ex.getClass()));
       }
     }
-    LOGGER.info("Missing imports: {}", missingImportListenerImpl.getNotImportUri());
     LOGGER.info("Ontology loading problems that occurred: {}", ontologyLoadingProblems);
     return umbrellaOntology;
   }

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/loader/CommandLineOntologyLoader.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/loader/CommandLineOntologyLoader.java
@@ -7,7 +7,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 import org.edmcouncil.spec.ontoviewer.configloader.configuration.model.ConfigurationData;
+import org.edmcouncil.spec.ontoviewer.configloader.utils.files.FileSystemManager;
+import org.edmcouncil.spec.ontoviewer.core.ontology.loader.listener.MissingImport;
 import org.edmcouncil.spec.ontoviewer.core.ontology.loader.listener.MissingImportListenerImpl;
+import org.edmcouncil.spec.ontoviewer.core.ontology.loader.zip.ViewerZipFilesOperations;
 import org.semanticweb.owlapi.apibinding.OWLManager;
 import org.semanticweb.owlapi.model.AddImport;
 import org.semanticweb.owlapi.model.IRI;
@@ -28,20 +31,29 @@ public class CommandLineOntologyLoader {
 
   private final ConfigurationData configurationData;
   private final MissingImportListenerImpl missingImportListenerImpl;
+  private final FileSystemManager fileSystemManager;
 
-  public CommandLineOntologyLoader(ConfigurationData configurationData) {
+  public CommandLineOntologyLoader(ConfigurationData configurationData,
+      FileSystemManager fileSystemManager) {
     this.configurationData = configurationData;
     this.missingImportListenerImpl = new MissingImportListenerImpl();
+    this.fileSystemManager = fileSystemManager;
   }
 
   public OWLOntology load() throws OWLOntologyCreationException {
+
+    ViewerZipFilesOperations viewerZipFilesOperations = new ViewerZipFilesOperations();
+    Set<MissingImport> missingImports = viewerZipFilesOperations
+        .prepareZipToLoad(configurationData, fileSystemManager);
+    this.missingImportListenerImpl.addAll(missingImports);
+    
     var owlOntologyManager = OWLManager.createOWLOntologyManager();
 
     setOntologyMapping(owlOntologyManager);
-    
+
     var ontologyIrisToLoad = new HashSet<IRI>();
     var ontologyMappings = new HashMap<String, String>();
-    
+
     var ontologyLocations = configurationData.getOntologiesConfig().getPaths();
     for (String ontologyLocation : ontologyLocations) {
       ontologyIrisToLoad.add(IRI.create(Path.of(ontologyLocation).toFile()));
@@ -63,14 +75,14 @@ public class CommandLineOntologyLoader {
             documentIri, fileIri);
       }
     });
-    
+
     return loadOntologiesFromIris(owlOntologyManager, ontologyIrisToLoad);
   }
 
   private void setOntologyMapping(OWLOntologyManager owlOntologyManager) {
     var ontologyMapping = configurationData.getOntologiesConfig().getOntologyMappings();
-    ontologyMapping.forEach((ontologyIri, ontologyPath) ->
-        owlOntologyManager.getIRIMappers().add(
+      ontologyMapping.forEach((ontologyIri, ontologyPath)
+        -> owlOntologyManager.getIRIMappers().add(
             new SimpleIRIMapper(
                 IRI.create(ontologyIri),
                 IRI.create(new File(ontologyPath)))));

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/loader/listener/MissingImportListenerImpl.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/loader/listener/MissingImportListenerImpl.java
@@ -26,4 +26,8 @@ public class MissingImportListenerImpl implements MissingImportListener {
   public Set<MissingImport> getNotImportUri() {
     return missingImports;
   }
+  
+  public void addAll(Set<MissingImport> missingImports){
+    this.missingImports.addAll(missingImports);
+  }
 }

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/loader/zip/ViewerZipFilesOperations.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/loader/zip/ViewerZipFilesOperations.java
@@ -1,0 +1,119 @@
+package org.edmcouncil.spec.ontoviewer.core.ontology.loader.zip;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import net.lingala.zip4j.ZipFile;
+import net.lingala.zip4j.exception.ZipException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.apache.commons.io.FileUtils; 
+import org.edmcouncil.spec.ontoviewer.configloader.configuration.model.ConfigurationData;
+import org.edmcouncil.spec.ontoviewer.configloader.utils.files.FileSystemManager;
+import org.edmcouncil.spec.ontoviewer.core.ontology.loader.listener.MissingImport;
+
+
+/**
+ *
+ * @author Michal Daniel(michal.daniel@makolab.com)
+ */
+public class ViewerZipFilesOperations {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ViewerZipFilesOperations.class);
+
+  @SuppressWarnings("null")
+  public Set<MissingImport> prepareZipToLoad(ConfigurationData config, FileSystemManager fileSystemManager) {
+    Set<MissingImport> missingImports = new LinkedHashSet<>();
+    List<String> zipUrls = config.getOntologiesConfig().getZipUrls();
+    List<String> downloadDirectory = config.getOntologiesConfig().getDownloadDirectory();
+    LOGGER.trace("Ontology ZIP URLS : {}", zipUrls);
+    LOGGER.trace("Ontology Download Dir : {}", downloadDirectory);
+    //checking if zip files can be downloaded at all
+    if(!zipUrls.isEmpty()
+        && !downloadDirectory.isEmpty()){
+      String downloadDirectoryFirst = downloadDirectory.stream().findFirst().get();
+      Path downloadDir = null;
+      try {
+        downloadDir = fileSystemManager.getPathToFile(downloadDirectoryFirst);
+      } catch (IOException e) {
+        LOGGER.error(e.toString());
+        MissingImport missingImport = new MissingImport();
+        missingImport.setIri(downloadDirectoryFirst);
+        missingImport.setCause(e.toString());
+        missingImports.add(missingImport);
+      }
+
+      if(downloadDir != null && downloadDir.toFile().exists() && downloadDir.toFile().isDirectory()){
+        try {
+          clearDirectory(downloadDir.toFile());
+        } catch (IOException ex) {
+          LOGGER.error(ex.toString());
+        }
+
+        for (String fileUrl : zipUrls) {
+          File downloadedFile = null;
+          try {
+            downloadedFile = downloadFileFromUrlToDir(fileUrl, downloadDir);
+          } catch (IOException ex) {
+            LOGGER.error(ex.toString());
+            MissingImport missingImport = new MissingImport();
+            missingImport.setIri(fileUrl);
+            missingImport.setCause(ex.toString());
+            missingImports.add(missingImport);
+          }
+          if(downloadedFile != null){
+            try {
+              unzipFolder(downloadedFile.toPath(), downloadDir);
+            } catch (ZipException ex) {
+              LOGGER.error(ex.toString());
+              MissingImport missingImport = new MissingImport();
+              missingImport.setIri(downloadedFile.toPath().toString());
+              missingImport.setCause(ex.toString());
+              missingImports.add(missingImport);
+            }
+            if(!downloadedFile.delete()){
+              LOGGER.error("Can not delete file: {}", downloadedFile.toPath().toString());
+            }
+          }
+        }
+
+      } else {
+        MissingImport missingImport = new MissingImport();
+        missingImport.setIri(downloadDir.toString());
+        missingImport.setCause("Download directory not exists or it's not 'directory'");
+        missingImports.add(missingImport);
+      }
+    }
+    return missingImports;
+  }
+
+  private File downloadFileFromUrlToDir(String fileUrl, Path downloadDir) throws MalformedURLException, IOException{
+    File outputFile = downloadDir
+      .resolve(fileUrl.substring(fileUrl.lastIndexOf("/")+1))
+      .toFile();
+    FileUtils.copyURLToFile(new URL(fileUrl), outputFile);
+    return outputFile;
+  }
+
+  private void unzipFolder(Path source, Path target) throws ZipException{
+    new ZipFile(source.toFile())
+                .extractAll(target.toString());
+  }
+
+  private void clearDirectory(File downloadDir) throws IOException {
+    File[] allContents = downloadDir.listFiles();
+    if (allContents != null) {
+        for (File file : allContents) {
+          if(file.isDirectory())
+            FileUtils.deleteDirectory(file);
+          file.delete();
+        }
+    }
+  }
+}

--- a/onto-viewer-web-app/src/main/java/org/edmcouncil/spec/ontoviewer/webapp/boot/UpdaterThread.java
+++ b/onto-viewer-web-app/src/main/java/org/edmcouncil/spec/ontoviewer/webapp/boot/UpdaterThread.java
@@ -17,6 +17,7 @@ import org.edmcouncil.spec.ontoviewer.core.ontology.updater.model.UpdateJob;
 import org.edmcouncil.spec.ontoviewer.core.ontology.updater.model.UpdateJobStatus;
 import org.edmcouncil.spec.ontoviewer.core.ontology.updater.util.UpdaterOperation;
 import org.edmcouncil.spec.ontoviewer.webapp.search.LuceneSearcher;
+import org.edmcouncil.spec.ontoviewer.core.ontology.loader.zip.ViewerZipFilesOperations;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
@@ -26,7 +27,7 @@ import org.slf4j.LoggerFactory;
 
 public abstract class UpdaterThread extends Thread implements Thread.UncaughtExceptionHandler {
 
-  private static final Logger LOG = LoggerFactory.getLogger(UpdaterThread.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(UpdaterThread.class);
   private static final String INTERRUPT_MESSAGE = "Interrupts this update. New update request.";
 
   private final OntologyManager ontologyManager;
@@ -73,7 +74,7 @@ public abstract class UpdaterThread extends Thread implements Thread.UncaughtExc
           String msg = String.format("UpdateJob with id: %s waiting to end other updates",
               job.getId());
           UpdaterOperation.setJobStatusToWaiting(job, msg);
-          LOG.debug(msg);
+          LOGGER.debug(msg);
           //Wait for one sec so it doesn't print too fast
           Thread.sleep(1000);
         } catch (InterruptedException e) {
@@ -98,13 +99,19 @@ public abstract class UpdaterThread extends Thread implements Thread.UncaughtExc
       Map<IRI, IRI> iriToPathMapping = new HashMap<>();
       String msgError = null;
 
-      LOG.info("File system manager created ? : {}", fileSystemManager != null);
+      LOGGER.info("File system manager created ? : {}", fileSystemManager != null);
 
       ConfigurationData configurationData = applicationConfigurationService.getConfigurationData();
 
       if (isInterrupt()) {
         throw new InterruptUpdate();
       }
+      
+          //ZIP Support 
+      ViewerZipFilesOperations viewerZipFilesOperations = new ViewerZipFilesOperations();
+      Set<MissingImport> missingImports = viewerZipFilesOperations.prepareZipToLoad(
+          applicationConfigurationService.getConfigurationData(), 
+          fileSystemManager);
 
       //download ontology file/files
       //load ontology to var
@@ -115,13 +122,13 @@ public abstract class UpdaterThread extends Thread implements Thread.UncaughtExc
         iriToPathMapping = loadedOntologyData.getIriToPathMapping();
       } catch (OWLOntologyCreationException ex) {
         msgError = ex.getMessage();
-        LOG.error(
+        LOGGER.error(
             "[ERROR]: Error when creating ontology. Stopping application. Exception: {} \n Message: {}",
             ex.getStackTrace(), ex.getMessage());
       }
 
       if (msgError != null) {
-        LOG.error("[ERROR]: Cannot update, id {}", job.getId());
+        LOGGER.error("[ERROR]: Cannot update, id {}", job.getId());
         job = UpdaterOperation.setJobStatusToError(job, msgError);
         blocker.setUpdateNow(Boolean.FALSE);
         return;
@@ -130,7 +137,8 @@ public abstract class UpdaterThread extends Thread implements Thread.UncaughtExc
         throw new InterruptUpdate();
       }
 
-      Set<MissingImport> missingImports = loader.getMissingImportListenerImpl().getNotImportUri();
+      missingImports.addAll(loader.getMissingImportListenerImpl().getNotImportUri());
+      LOGGER.info("Missing imports: {}", missingImports);
 
       Set<String> scopes = scopeIriOntology.getScopeIri(ontology);
 
@@ -167,9 +175,9 @@ public abstract class UpdaterThread extends Thread implements Thread.UncaughtExc
         blocker.setInitializeAppDone(Boolean.TRUE);
       }
 
-      LOG.info("Application has started successfully.");
+      LOGGER.info("Application has started successfully.");
     } catch (InterruptUpdate ex) {
-      LOG.error("{}", ex.getStackTrace());
+      LOGGER.error("{}", ex.getStackTrace());
       UpdaterOperation.setJobStatusToError(job, INTERRUPT_MESSAGE);
       blocker.setUpdateNow(Boolean.FALSE);
       this.interrupt();
@@ -184,7 +192,7 @@ public abstract class UpdaterThread extends Thread implements Thread.UncaughtExc
   @Override
   public void uncaughtException(Thread t, Throwable e) {
     UpdaterOperation.setJobStatusToError(job, e.getMessage());
-    LOG.error(e.getStackTrace().toString());
+    LOGGER.error(e.getStackTrace().toString());
     blocker.setUpdateNow(Boolean.FALSE);
   }
 

--- a/onto-viewer-web-app/src/main/resources/application.properties
+++ b/onto-viewer-web-app/src/main/resources/application.properties
@@ -21,3 +21,5 @@ logging.level.org.edmcouncil.spec.ontoviewer=INFO
 app.search.reindexOnStart=true
 app.search.fuzzyDistance=3
 app.config.ontologies.catalog_path=
+app.config.ontologies.download_directory=
+app.config.ontologies.zip_url=


### PR DESCRIPTION
Signed-off-by: Michał Daniel <michal.daniel@makolab.com>

## Description

Downloading, unzipping and deleting the zip file is done before the ontology is loaded. The folder with the downloaded data should be added to the configuration as source.

Orginal: #223 
Fixes #222 

## Example yaml config: 
```
ontologies:
  download_directory: 
    - download
  source:
    - zip: 'https://spec.edmcouncil.org/fibo/ontology/master/latest/dev.rdf.zip'
    - path: staticOntologies
    - path: download
  catalog_path:
    - ontologies/catalog-v001.xml
  module_ignore_pattern:
    - '^(About|Metadata|Load).*'
    - 'http.*(About|Metadata).*'

```

Override from command line: 
- download directory => `-Dapp.config.ontologies.download_directory=downloadDirectory`
- source zip url =>  `-Dapp.config.ontologies.zip_url=https://spec.edmcouncil.org/fibo/ontology/master/latest/dev.rdf.zip`