### PR TITLE
Display GCIs

### DIFF
--- a/onto-viewer-config-loader/src/main/resources/default_groups_config.yaml
+++ b/onto-viewer-config-loader/src/main/resources/default_groups_config.yaml
@@ -29,6 +29,7 @@ groups_config:
         - '@viewer.function.instances'
         - '@viewer.axiom.EquivalentClasses'
         - '@viewer.axiom.SubClassOf'
+        - '@viewer.axiom.gci'
         - '@viewer.function.anonymous_ancestor'
         - '@viewer.axiom.DisjointClasses'
         - '@viewer.axiom.ClassAssertion'

--- a/onto-viewer-config-loader/src/main/resources/default_label_config.yaml
+++ b/onto-viewer-config-loader/src/main/resources/default_label_config.yaml
@@ -93,3 +93,5 @@ label_config:
       name: number of datatypes
     - id: '@viewer.stats.numberOfOntologies'
       name: number of ontologies
+    - id: '@viewer.axiom.gci'
+      name: General class axiom

--- a/onto-viewer-config-loader/src/test/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/service/YamlFileBasedConfigurationServiceTest.java
+++ b/onto-viewer-config-loader/src/test/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/service/YamlFileBasedConfigurationServiceTest.java
@@ -44,7 +44,7 @@ class YamlFileBasedConfigurationServiceTest {
     assertFalse(configurationData.getLabelConfig().isForceLabelLang());
     assertEquals("en", configurationData.getLabelConfig().getLabelLang());
     assertEquals(MissingLanguageAction.FIRST, configurationData.getLabelConfig().getMissingLanguageAction());
-    assertEquals(44, configurationData.getLabelConfig().getDefaultNames().size());
+    assertEquals(45, configurationData.getLabelConfig().getDefaultNames().size());
 
     // Ontology Config
     assertEquals("ontologies", configurationData.getOntologiesConfig().getPaths().get(0));
@@ -85,7 +85,7 @@ class YamlFileBasedConfigurationServiceTest {
     assertFalse(configurationData.getLabelConfig().isForceLabelLang());
     assertEquals("en", configurationData.getLabelConfig().getLabelLang());
     assertEquals(MissingLanguageAction.FIRST, configurationData.getLabelConfig().getMissingLanguageAction());
-    assertEquals(44, configurationData.getLabelConfig().getDefaultNames().size());
+    assertEquals(45, configurationData.getLabelConfig().getDefaultNames().size());
 
     // Ontology Config
     assertEquals("ontologies", configurationData.getOntologiesConfig().getPaths().get(0));
@@ -159,7 +159,7 @@ class YamlFileBasedConfigurationServiceTest {
     assertFalse(configurationData.getLabelConfig().isForceLabelLang());
     assertEquals("en", configurationData.getLabelConfig().getLabelLang());
     assertEquals(MissingLanguageAction.FIRST, configurationData.getLabelConfig().getMissingLanguageAction());
-    assertEquals(44, configurationData.getLabelConfig().getDefaultNames().size());
+    assertEquals(45, configurationData.getLabelConfig().getDefaultNames().size());
 
     // Ontology Config
     var ontologiesConfig = configurationData.getOntologiesConfig();
@@ -202,7 +202,7 @@ class YamlFileBasedConfigurationServiceTest {
     assertFalse(configurationData.getLabelConfig().isForceLabelLang());
     assertEquals("en", configurationData.getLabelConfig().getLabelLang());
     assertEquals(MissingLanguageAction.FIRST, configurationData.getLabelConfig().getMissingLanguageAction());
-    assertEquals(44, configurationData.getLabelConfig().getDefaultNames().size());
+    assertEquals(45, configurationData.getLabelConfig().getDefaultNames().size());
 
     // Ontology Config
     assertEquals("ontologies", configurationData.getOntologiesConfig().getPaths().get(0));
@@ -241,7 +241,7 @@ class YamlFileBasedConfigurationServiceTest {
     assertFalse(configurationData.getLabelConfig().isForceLabelLang());
     assertEquals("en", configurationData.getLabelConfig().getLabelLang());
     assertEquals(MissingLanguageAction.FIRST, configurationData.getLabelConfig().getMissingLanguageAction());
-    assertEquals(44, configurationData.getLabelConfig().getDefaultNames().size());
+    assertEquals(45, configurationData.getLabelConfig().getDefaultNames().size());
 
     // Ontology Config
     assertEquals("ontologies", configurationData.getOntologiesConfig().getPaths().get(0));

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/extractor/TaxonomyExtractor.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/extractor/TaxonomyExtractor.java
@@ -27,9 +27,9 @@ public class TaxonomyExtractor {
 
   private static final Logger LOG = LoggerFactory.getLogger(TaxonomyExtractor.class);
 
-  private LabelProvider labelProvider;
-  private ClassDataHelper extractSubAndSuper;
-  private AxiomsHelper axiomsHelper;
+  private final LabelProvider labelProvider;
+  private final ClassDataHelper extractSubAndSuper;
+  private final AxiomsHelper axiomsHelper;
 
   public TaxonomyExtractor(LabelProvider labelProvider, ClassDataHelper extractSubAndSuper,
       AxiomsHelper axiomsHelper) {

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/extractor/UsageExtractor.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/extractor/UsageExtractor.java
@@ -77,8 +77,8 @@ public class UsageExtractor {
 
     int start = 0;
     for (OWLSubClassOfAxiom axiom : axioms) {
-      LOG.debug("OwlDataHandler -> extractUsage {}", axiom.toString());
-      LOG.debug("OwlDataHandler -> extractUsageAx {}", axiom.getSubClass());
+      LOG.debug("Extract Usage as String {}", axiom.toString());
+      LOG.debug("Extract Usage subCLass {}", axiom.getSubClass());
 
       IRI iri = null;
       if(axiom.getSubClass().isOWLClass()){
@@ -87,6 +87,7 @@ public class UsageExtractor {
           continue;
         }
       } else {
+        //bypassing GCI
         continue;
       }
       String iriFragment = iri.getFragment();

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/axiom/AxiomsHandler.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/axiom/AxiomsHandler.java
@@ -45,24 +45,24 @@ public class AxiomsHandler {
   }
 
   public OwlDetailsProperties<PropertyValue> handle(
-          OWLNamedIndividual obj,
-          OWLOntology ontology) {
+      OWLNamedIndividual obj,
+      OWLOntology ontology) {
 
     Iterator<OWLIndividualAxiom> axiomsIterator = ontology.axioms(obj, INCLUDED).iterator();
     return handle(axiomsIterator, obj.getIRI());
   }
 
   public OwlDetailsProperties<PropertyValue> handle(
-          OWLObjectProperty obj,
-          OWLOntology ontology) {
+      OWLObjectProperty obj,
+      OWLOntology ontology) {
 
     Iterator<OWLObjectPropertyAxiom> axiomsIterator = ontology.axioms(obj, INCLUDED).iterator();
     return handle(axiomsIterator, obj.getIRI());
   }
 
   public OwlDetailsProperties<PropertyValue> handle(
-          OWLDataProperty obj,
-          OWLOntology ontology) {
+      OWLDataProperty obj,
+      OWLOntology ontology) {
     Iterator<OWLDataPropertyAxiom> axiomsIterator = ontology.axioms(obj, INCLUDED).iterator();
     return handle(axiomsIterator, obj.getIRI());
   }
@@ -88,15 +88,15 @@ public class AxiomsHandler {
   }
 
   public OwlDetailsProperties<PropertyValue> handle(
-          OWLAnnotationProperty obj,
-          OWLOntology ontology) {
+      OWLAnnotationProperty obj,
+      OWLOntology ontology) {
     Iterator<OWLAnnotationAxiom> axiomsIterator = ontology.axioms(obj, INCLUDED).iterator();
     return handle(axiomsIterator, obj.getIRI());
   }
 
   private <T extends OWLAxiom> OwlDetailsProperties<PropertyValue> handle(
-          Iterator<T> axiomsIterator,
-          IRI elementIri) {
+      Iterator<T> axiomsIterator,
+      IRI elementIri) {
     OwlDetailsProperties<PropertyValue> result = new OwlDetailsProperties<>();
     String iriFragment = elementIri.getFragment();
     String splitFragment = StringUtils.getIdentifier(elementIri);
@@ -117,8 +117,8 @@ public class AxiomsHandler {
       key = ViewerIdentifierFactory.createId(ViewerIdentifierFactory.Type.axiom, key);
 
       OwlAxiomPropertyValue opv = axiomsHelper.prepareAxiomPropertyValue(axiom, iriFragment,
-              splitFragment,
-              fixRenderedIri, key, start, true);
+        splitFragment,
+        fixRenderedIri, key, start, true);
 
       if (opv == null) {
         continue;

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/axiom/AxiomsHandler.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/axiom/AxiomsHandler.java
@@ -4,12 +4,16 @@ import static org.edmcouncil.spec.ontoviewer.core.model.OwlType.TAXONOMY;
 import static org.semanticweb.owlapi.model.parameters.Imports.INCLUDED;
 
 import java.util.Iterator;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.edmcouncil.spec.ontoviewer.core.model.PropertyValue;
 import org.edmcouncil.spec.ontoviewer.core.model.property.OwlAxiomPropertyValue;
 import org.edmcouncil.spec.ontoviewer.core.model.property.OwlDetailsProperties;
 import org.edmcouncil.spec.ontoviewer.core.ontology.data.handler.StringIdentifier;
+import org.edmcouncil.spec.ontoviewer.core.ontology.data.visitor.ContainsVisitors;
 import org.edmcouncil.spec.ontoviewer.core.ontology.factory.ViewerIdentifierFactory;
 import org.edmcouncil.spec.ontoviewer.core.utils.StringUtils;
+import org.semanticweb.owlapi.model.AxiomType;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLAnnotationAxiom;
 import org.semanticweb.owlapi.model.OWLAnnotationProperty;
@@ -23,6 +27,7 @@ import org.semanticweb.owlapi.model.OWLNamedIndividual;
 import org.semanticweb.owlapi.model.OWLObjectProperty;
 import org.semanticweb.owlapi.model.OWLObjectPropertyAxiom;
 import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -32,49 +37,66 @@ public class AxiomsHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(AxiomsHandler.class);
   private final AxiomsHelper axiomsHelper;
+  private final ContainsVisitors containsVisitors;
 
-  public AxiomsHandler(AxiomsHelper axiomsHelper) {
+  public AxiomsHandler(AxiomsHelper axiomsHelper, ContainsVisitors containsVisitors) {
     this.axiomsHelper = axiomsHelper;
+    this.containsVisitors = containsVisitors;
   }
 
   public OwlDetailsProperties<PropertyValue> handle(
-      OWLNamedIndividual obj,
-      OWLOntology ontology) {
+          OWLNamedIndividual obj,
+          OWLOntology ontology) {
 
     Iterator<OWLIndividualAxiom> axiomsIterator = ontology.axioms(obj, INCLUDED).iterator();
     return handle(axiomsIterator, obj.getIRI());
   }
 
   public OwlDetailsProperties<PropertyValue> handle(
-      OWLObjectProperty obj,
-      OWLOntology ontology) {
+          OWLObjectProperty obj,
+          OWLOntology ontology) {
 
     Iterator<OWLObjectPropertyAxiom> axiomsIterator = ontology.axioms(obj, INCLUDED).iterator();
     return handle(axiomsIterator, obj.getIRI());
   }
 
   public OwlDetailsProperties<PropertyValue> handle(
-      OWLDataProperty obj,
-      OWLOntology ontology) {
+          OWLDataProperty obj,
+          OWLOntology ontology) {
     Iterator<OWLDataPropertyAxiom> axiomsIterator = ontology.axioms(obj, INCLUDED).iterator();
     return handle(axiomsIterator, obj.getIRI());
   }
 
   public OwlDetailsProperties<PropertyValue> handle(OWLClass obj, OWLOntology ontology) {
-    Iterator<OWLClassAxiom> axiomsIterator = ontology.axioms(obj, INCLUDED).iterator();
-    return handle(axiomsIterator, obj.getIRI());
+    return handle(obj, ontology, false);
+  }
+
+  public OwlDetailsProperties<PropertyValue> handle(OWLClass obj, OWLOntology ontology, boolean extractGCI) {
+    Set<OWLClassAxiom> axiomsSet = ontology.axioms(obj, INCLUDED).collect(Collectors.toSet());
+
+    if (extractGCI) {
+      ontology.importsClosure().forEach(currentOntology -> {
+        axiomsSet.addAll(
+          currentOntology.axioms(AxiomType.SUBCLASS_OF)
+            .filter(el -> el.isGCI())
+            .filter(el -> el.accept(containsVisitors.visitor(obj.getIRI())))
+            .collect(Collectors.toSet()));
+      });
+    }
+
+    return handle(axiomsSet.iterator(), obj.getIRI());
   }
 
   public OwlDetailsProperties<PropertyValue> handle(
-      OWLAnnotationProperty obj,
-      OWLOntology ontology) {
+          OWLAnnotationProperty obj,
+          OWLOntology ontology) {
     Iterator<OWLAnnotationAxiom> axiomsIterator = ontology.axioms(obj, INCLUDED).iterator();
     return handle(axiomsIterator, obj.getIRI());
   }
 
   private <T extends OWLAxiom> OwlDetailsProperties<PropertyValue> handle(
-      Iterator<T> axiomsIterator,
-      IRI elementIri) {
+          Iterator<T> axiomsIterator,
+          IRI elementIri) {
     OwlDetailsProperties<PropertyValue> result = new OwlDetailsProperties<>();
     String iriFragment = elementIri.getFragment();
     String splitFragment = StringUtils.getIdentifier(elementIri);
@@ -86,11 +108,17 @@ public class AxiomsHandler {
       T axiom = axiomsIterator.next();
 
       String key = axiom.getAxiomType().getName();
+      if (axiom instanceof OWLSubClassOfAxiom) {
+        OWLSubClassOfAxiom clazzAxiom = (OWLSubClassOfAxiom) axiom;
+        if (clazzAxiom.isGCI()) {
+          key = "gci";
+        }
+      }
       key = ViewerIdentifierFactory.createId(ViewerIdentifierFactory.Type.axiom, key);
 
       OwlAxiomPropertyValue opv = axiomsHelper.prepareAxiomPropertyValue(axiom, iriFragment,
-          splitFragment,
-          fixRenderedIri, key, start, true);
+              splitFragment,
+              fixRenderedIri, key, start, true);
 
       if (opv == null) {
         continue;

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/axiom/AxiomsHelper.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/axiom/AxiomsHelper.java
@@ -15,6 +15,7 @@ import org.semanticweb.owlapi.manchestersyntax.renderer.ManchesterOWLSyntaxOWLOb
 import org.semanticweb.owlapi.model.AxiomType;
 import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLEntity;
+import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -210,7 +211,16 @@ public class AxiomsHelper {
 
     boolean isRestriction = owlUtils.isRestriction(axiom);
     if (!isRestriction && axiom.getAxiomType().equals(AxiomType.SUBCLASS_OF)) {
-      axiomPropertyValue.setType(OwlType.TAXONOMY);
+      OwlType type = OwlType.TAXONOMY;
+      
+      if(axiom instanceof OWLSubClassOfAxiom){
+        OWLSubClassOfAxiom clazzAxiom = (OWLSubClassOfAxiom)axiom;
+        if(clazzAxiom.isGCI()){
+          type = OwlType.AXIOM;
+        }
+      } 
+      
+      axiomPropertyValue.setType(type);
     }
 
     processingAxioms(axiom, fixRenderedIri, iriFragment, splitFragment, axiomPropertyValue, value,

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/axiom/InheritedAxiomsHandler.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/axiom/InheritedAxiomsHandler.java
@@ -29,7 +29,7 @@ public class InheritedAxiomsHandler {
   private final AxiomsHandler axiomsHandler;
 
   public InheritedAxiomsHandler(Parser parser, LabelProvider labelProvider, OwlUtils owlUtils,
-          AxiomsHandler axiomsHandler) {
+      AxiomsHandler axiomsHandler) {
     this.parser = parser;
     this.labelProvider = labelProvider;
     this.owlUtils = owlUtils;
@@ -44,55 +44,55 @@ public class InheritedAxiomsHandler {
 //   * @return Class and properties of Inherited Axioms.
 //   */
   public OwlDetailsProperties<PropertyValue> handle(OWLOntology ontology,
-          OWLClass clazz) {
+      OWLClass clazz) {
     OwlDetailsProperties<PropertyValue> result = new OwlDetailsProperties<>();
     String subClassOfKey = ViewerIdentifierFactory.createId(
-            ViewerIdentifierFactory.Type.axiom,
-            "SubClassOf");
+        ViewerIdentifierFactory.Type.axiom,
+        "SubClassOf");
     String equivalentClassKey = ViewerIdentifierFactory.createId(
-            ViewerIdentifierFactory.Type.axiom,
-            "EquivalentClasses");
+        ViewerIdentifierFactory.Type.axiom,
+        "EquivalentClasses");
     String key = ViewerIdentifierFactory.createId(
-            ViewerIdentifierFactory.Type.function,
-            OwlType.ANONYMOUS_ANCESTOR.name().toLowerCase());
+        ViewerIdentifierFactory.Type.function,
+        OwlType.ANONYMOUS_ANCESTOR.name().toLowerCase());
 
     Set<OWLClassExpression> alreadySeen = new HashSet<>();
     Set<OWLClass> rset = owlUtils.getSuperClasses(clazz, ontology, alreadySeen);
     Map<IRI, Set<OwlAxiomPropertyValue>> values = new HashMap<>();
 
     rset.stream()
-            .forEachOrdered((c) -> {
-              OwlDetailsProperties<PropertyValue> handleAxioms = axiomsHandler.
-                      handle(c, ontology);
-              for (Map.Entry<String, List<PropertyValue>> entry : handleAxioms.getProperties()
-                      .entrySet()) {
+      .forEachOrdered((c) -> {
+        OwlDetailsProperties<PropertyValue> handleAxioms = axiomsHandler
+           .handle(c, ontology);
+        for (Map.Entry<String, List<PropertyValue>> entry : handleAxioms.getProperties()
+            .entrySet()) {
 
-                if (entry.getKey().equals(subClassOfKey) || entry.getKey().equals(equivalentClassKey)) {
+          if (entry.getKey().equals(subClassOfKey) || entry.getKey().equals(equivalentClassKey)) {
 
-                  for (PropertyValue propertyValue : entry.getValue()) {
-                    if (propertyValue.getType() != OwlType.TAXONOMY) {
+            for (PropertyValue propertyValue : entry.getValue()) {
+              if (propertyValue.getType() != OwlType.TAXONOMY) {
 
-                      if (entry.getKey().equals(equivalentClassKey)) {
-                        OwlAxiomPropertyValue opv = (OwlAxiomPropertyValue) propertyValue;
-                        String val = opv.getValue();
-                        String[] value = val.split(" ");
-                        value[0] = value[1] = "";
-                        val = String.join(" ", value);
-                        opv.setValue(val);
-                      }
-                      OwlAxiomPropertyValue opv = (OwlAxiomPropertyValue) propertyValue;
-
-                      Set<OwlAxiomPropertyValue> owlAxiomPropertyValues = values.getOrDefault(
-                              c.getIRI(), new LinkedHashSet<>());
-
-                      owlAxiomPropertyValues.add(opv);
-                      values.put(c.getIRI(), owlAxiomPropertyValues);
-
-                    }
-                  }
+                if (entry.getKey().equals(equivalentClassKey)) {
+                  OwlAxiomPropertyValue opv = (OwlAxiomPropertyValue) propertyValue;
+                  String val = opv.getValue();
+                  String[] value = val.split(" ");
+                  value[0] = value[1] = "";
+                  val = String.join(" ", value);
+                  opv.setValue(val);
                 }
+                OwlAxiomPropertyValue opv = (OwlAxiomPropertyValue) propertyValue;
+
+                Set<OwlAxiomPropertyValue> owlAxiomPropertyValues = values.getOrDefault(
+                    c.getIRI(), new LinkedHashSet<>());
+
+                owlAxiomPropertyValues.add(opv);
+                values.put(c.getIRI(), owlAxiomPropertyValues);
+
               }
-            });
+            }
+          }
+        }
+      });
 
     StringBuilder sb = new StringBuilder();
 
@@ -110,7 +110,7 @@ public class InheritedAxiomsHandler {
         }
 
         for (Map.Entry<String, OwlAxiomPropertyEntity> mapping : owlAxiomPropertyValue.getEntityMaping()
-                .entrySet()) {
+            .entrySet()) {
           opv.addEntityValues(mapping.getKey(), mapping.getValue());
         }
       }

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/axiom/InheritedAxiomsHandler.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/axiom/InheritedAxiomsHandler.java
@@ -29,7 +29,7 @@ public class InheritedAxiomsHandler {
   private final AxiomsHandler axiomsHandler;
 
   public InheritedAxiomsHandler(Parser parser, LabelProvider labelProvider, OwlUtils owlUtils,
-      AxiomsHandler axiomsHandler) {
+          AxiomsHandler axiomsHandler) {
     this.parser = parser;
     this.labelProvider = labelProvider;
     this.owlUtils = owlUtils;
@@ -44,55 +44,55 @@ public class InheritedAxiomsHandler {
 //   * @return Class and properties of Inherited Axioms.
 //   */
   public OwlDetailsProperties<PropertyValue> handle(OWLOntology ontology,
-      OWLClass clazz) {
+          OWLClass clazz) {
     OwlDetailsProperties<PropertyValue> result = new OwlDetailsProperties<>();
     String subClassOfKey = ViewerIdentifierFactory.createId(
-        ViewerIdentifierFactory.Type.axiom,
-        "SubClassOf");
+            ViewerIdentifierFactory.Type.axiom,
+            "SubClassOf");
     String equivalentClassKey = ViewerIdentifierFactory.createId(
-        ViewerIdentifierFactory.Type.axiom,
-        "EquivalentClasses");
+            ViewerIdentifierFactory.Type.axiom,
+            "EquivalentClasses");
     String key = ViewerIdentifierFactory.createId(
-        ViewerIdentifierFactory.Type.function,
-        OwlType.ANONYMOUS_ANCESTOR.name().toLowerCase());
+            ViewerIdentifierFactory.Type.function,
+            OwlType.ANONYMOUS_ANCESTOR.name().toLowerCase());
 
     Set<OWLClassExpression> alreadySeen = new HashSet<>();
     Set<OWLClass> rset = owlUtils.getSuperClasses(clazz, ontology, alreadySeen);
     Map<IRI, Set<OwlAxiomPropertyValue>> values = new HashMap<>();
 
     rset.stream()
-        .forEachOrdered((c) -> {
-          OwlDetailsProperties<PropertyValue> handleAxioms = axiomsHandler.handle(c,
-              ontology);
-          for (Map.Entry<String, List<PropertyValue>> entry : handleAxioms.getProperties()
-              .entrySet()) {
+            .forEachOrdered((c) -> {
+              OwlDetailsProperties<PropertyValue> handleAxioms = axiomsHandler.
+                      handle(c, ontology);
+              for (Map.Entry<String, List<PropertyValue>> entry : handleAxioms.getProperties()
+                      .entrySet()) {
 
-            if (entry.getKey().equals(subClassOfKey) || entry.getKey().equals(equivalentClassKey)) {
+                if (entry.getKey().equals(subClassOfKey) || entry.getKey().equals(equivalentClassKey)) {
 
-              for (PropertyValue propertyValue : entry.getValue()) {
-                if (propertyValue.getType() != OwlType.TAXONOMY) {
+                  for (PropertyValue propertyValue : entry.getValue()) {
+                    if (propertyValue.getType() != OwlType.TAXONOMY) {
 
-                  if (entry.getKey().equals(equivalentClassKey)) {
-                    OwlAxiomPropertyValue opv = (OwlAxiomPropertyValue) propertyValue;
-                    String val = opv.getValue();
-                    String[] value = val.split(" ");
-                    value[0] = value[1] = "";
-                    val = String.join(" ", value);
-                    opv.setValue(val);
+                      if (entry.getKey().equals(equivalentClassKey)) {
+                        OwlAxiomPropertyValue opv = (OwlAxiomPropertyValue) propertyValue;
+                        String val = opv.getValue();
+                        String[] value = val.split(" ");
+                        value[0] = value[1] = "";
+                        val = String.join(" ", value);
+                        opv.setValue(val);
+                      }
+                      OwlAxiomPropertyValue opv = (OwlAxiomPropertyValue) propertyValue;
+
+                      Set<OwlAxiomPropertyValue> owlAxiomPropertyValues = values.getOrDefault(
+                              c.getIRI(), new LinkedHashSet<>());
+
+                      owlAxiomPropertyValues.add(opv);
+                      values.put(c.getIRI(), owlAxiomPropertyValues);
+
+                    }
                   }
-                  OwlAxiomPropertyValue opv = (OwlAxiomPropertyValue) propertyValue;
-
-                  Set<OwlAxiomPropertyValue> owlAxiomPropertyValues = values.getOrDefault(
-                      c.getIRI(), new LinkedHashSet<>());
-
-                  owlAxiomPropertyValues.add(opv);
-                  values.put(c.getIRI(), owlAxiomPropertyValues);
-
                 }
               }
-            }
-          }
-        });
+            });
 
     StringBuilder sb = new StringBuilder();
 
@@ -110,7 +110,7 @@ public class InheritedAxiomsHandler {
         }
 
         for (Map.Entry<String, OwlAxiomPropertyEntity> mapping : owlAxiomPropertyValue.getEntityMaping()
-            .entrySet()) {
+                .entrySet()) {
           opv.addEntityValues(mapping.getKey(), mapping.getValue());
         }
       }

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/classes/ClassHandler.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/classes/ClassHandler.java
@@ -94,7 +94,7 @@ public class ClassHandler {
     try {
       resultDetails.setLabel(labelProvider.getLabelOrDefaultFragment(owlClass));
 
-      OwlDetailsProperties<PropertyValue> axioms = axiomsHandler.handle(owlClass, ontology);
+      OwlDetailsProperties<PropertyValue> axioms = axiomsHandler.handle(owlClass, ontology, true);
       List<PropertyValue> subclasses = extractSubAndSuper.getSubclasses(axioms);
       List<PropertyValue> subclasses2 = extractSubAndSuper.getSuperClasses(owlClass);
       List<PropertyValue> taxElements2 = taxonomyExtractor.extractTaxonomyElements(subclasses2);

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/data/AnnotationsDataHandler.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/data/AnnotationsDataHandler.java
@@ -115,7 +115,7 @@ public class AnnotationsDataHandler {
         annotationsForAnnotationAssertion.put(owlAnnotation.getProperty().getIRI().getIRIString(),
             annotationValue);
       }
- 
+
       String value = annotationAssertion.annotationValue().toString();
       PropertyValue annotationPropertyValue = new OwlAnnotationPropertyValueWithSubAnnotations();
       ((OwlAnnotationPropertyValueWithSubAnnotations) annotationPropertyValue).setSubAnnotations(
@@ -125,7 +125,7 @@ public class AnnotationsDataHandler {
 
       annotationPropertyValue = getAnnotationPropertyValue(annotationAssertion, value,
           annotationPropertyValue);
-      
+
       if (propertyIri.equals(COMMENT_IRI) && value.contains(FIBO_QNAME)) {
         details.setqName(value);
         continue;

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/data/AnnotationsDataHandler.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/data/AnnotationsDataHandler.java
@@ -3,10 +3,8 @@ package org.edmcouncil.spec.ontoviewer.core.ontology.data.handler.data;
 import static org.edmcouncil.spec.ontoviewer.core.model.OwlType.AXIOM_ANNOTATION_PROPERTY;
 import static org.semanticweb.owlapi.model.parameters.Imports.INCLUDED;
 
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -117,7 +115,7 @@ public class AnnotationsDataHandler {
         annotationsForAnnotationAssertion.put(owlAnnotation.getProperty().getIRI().getIRIString(),
             annotationValue);
       }
-
+ 
       String value = annotationAssertion.annotationValue().toString();
       PropertyValue annotationPropertyValue = new OwlAnnotationPropertyValueWithSubAnnotations();
       ((OwlAnnotationPropertyValueWithSubAnnotations) annotationPropertyValue).setSubAnnotations(
@@ -127,7 +125,7 @@ public class AnnotationsDataHandler {
 
       annotationPropertyValue = getAnnotationPropertyValue(annotationAssertion, value,
           annotationPropertyValue);
-
+      
       if (propertyIri.equals(COMMENT_IRI) && value.contains(FIBO_QNAME)) {
         details.setqName(value);
         continue;


### PR DESCRIPTION
## Description

GCIs is treated like any axiom, for the separation of GCIs the target group is changed. As a specific GCI appears in every resource it contains it is omitted from usage extractor functions. 

Label in default config: `General class axiom`
Group in default config: `Ontological characteristic`

To setup own label or group use id: `@viewer.axiom.gci` in config files, examples in this PR ([default_groups_config.yaml#L32](https://github.com/edmcouncil/onto-viewer/blob/07e1851a18c154fd72300849e979a6c5503c7328/onto-viewer-config-loader/src/main/resources/default_groups_config.yaml#L32),  [default_label_config.yaml#L96](https://github.com/edmcouncil/onto-viewer/blob/07e1851a18c154fd72300849e979a6c5503c7328/onto-viewer-config-loader/src/main/resources/default_label_config.yaml#L96)).

Resolve: #333 