### PR TITLE
Onto-viewer-toolkit fails for data-dictionary product

### DIFF
--- a/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/model/ConfigurationData.java
+++ b/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/model/ConfigurationData.java
@@ -1,5 +1,6 @@
 package org.edmcouncil.spec.ontoviewer.configloader.configuration.model;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -242,11 +243,24 @@ public class ConfigurationData {
     private final List<String> zipUrls;
     private final String moduleClassIri;
     private List<Pair> maturityLevelDefinition;
+    private String maturityLevelProperty;
+
+    public OntologiesConfig() {
+      urls = new ArrayList<>();
+      paths = new ArrayList<>();
+      catalogPaths = new ArrayList<>();
+      moduleIgnorePatterns = new ArrayList<>();
+      moduleToIgnore = new ArrayList<>();
+      ontologyMappings = new HashMap<>();
+      downloadDirectory = new ArrayList<>();
+      zipUrls = new ArrayList<>();
+      moduleClassIri = "";
+    }
 
     public OntologiesConfig(List<String> urls, List<String> paths, List<String> catalogPaths,
         List<String> downloadDirectory, List<String> zipUrls, List<String> moduleIgnorePatterns,
         List<String> moduleToIgnore, List<Pair> maturityLevelDefinition, boolean automaticCreationOfModules,
-        String moduleClassIri) {
+        String moduleClassIri, String maturityLevelProperty) {
       this.urls = urls;
       this.paths = paths;
       this.catalogPaths = catalogPaths;
@@ -258,6 +272,7 @@ public class ConfigurationData {
       this.downloadDirectory = downloadDirectory;
       this.zipUrls = zipUrls;
       this.moduleClassIri = moduleClassIri;
+      this.maturityLevelProperty = maturityLevelProperty;
     }
 
     public List<String> getUrls() {
@@ -310,6 +325,14 @@ public class ConfigurationData {
 
     public String getModuleClassIri() {
       return moduleClassIri;
+    }
+
+    public String getMaturityLevelProperty() {
+      return maturityLevelProperty;
+    }
+
+    public void setMaturityLevelProperty(String maturityLevelProperty) {
+      this.maturityLevelProperty = maturityLevelProperty;
     }
   }
 

--- a/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/model/ConfigurationKey.java
+++ b/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/model/ConfigurationKey.java
@@ -39,6 +39,7 @@ public enum ConfigurationKey {
   AUTOMATIC_CREATION_OF_MODULES("automatic_creation_of_modules"),
   MODULE_CLASS_IRI("module_class_iri"),
   MATURITY_LEVEL_DEFINITION("maturity_level_definition"),
+  MATURITY_LEVEL_PROPERTY("maturity_level_property"),
   //ApplicationConfig
   APPLICATION_CONFIG("application_config"),
   LICENSE("license"),

--- a/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/service/AbstractYamlConfigurationService.java
+++ b/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/service/AbstractYamlConfigurationService.java
@@ -86,7 +86,7 @@ public abstract class AbstractYamlConfigurationService implements ApplicationCon
           break;
         case ONTOLOGIES:
           @SuppressWarnings("unchecked")
-          var ontologiesConfig = handleOntologies((Map<String, Object>) entry.getValue());
+          var ontologiesConfig = handleOntologyConfig((Map<String, Object>) entry.getValue(), new OntologiesConfig());
           configuration.setOntologiesConfig(ontologiesConfig);
           break;
         case INTEGRATIONS:
@@ -137,8 +137,8 @@ public abstract class AbstractYamlConfigurationService implements ApplicationCon
 
     return new GroupsConfig(priorityList, groups);
   }
-  
-  protected ApplicationConfig handleApplicationConfig(Map<String, Object> applicationConfig){
+
+  protected ApplicationConfig handleApplicationConfig(Map<String, Object> applicationConfig) {
 
     var licenseObject = applicationConfig.get(LICENSE.getLabel());
     List<String> license = getListOfStringsFromObject(licenseObject);
@@ -157,7 +157,7 @@ public abstract class AbstractYamlConfigurationService implements ApplicationCon
 
     return new ApplicationConfig(license, copyright, displayLicense, displayCopyright, displayQName);
   }
-  
+
   protected LabelConfig handleLabelConfig(Map<String, Object> labelConfig) {
     var displayLabelObject = labelConfig.get(DISPLAY_LABEL.getLabel());
     boolean displayLabel = getBooleanFromObject(displayLabelObject, DISPLAY_LABEL_DEFAULT);
@@ -217,7 +217,7 @@ public abstract class AbstractYamlConfigurationService implements ApplicationCon
     return new SearchConfig(searchDescriptions, fuzzyDistance, reindexOnStart, findProperties);
   }
 
-  protected OntologiesConfig handleOntologies(Map<String, Object> ontologies) {
+  protected OntologiesConfig handleOntologyConfig(Map<String, Object> ontologies, OntologiesConfig ontologiesConfig) {
     List<String> urls = new ArrayList<>();
     List<String> paths = new ArrayList<>();
     List<String> zips = new ArrayList<>();
@@ -246,14 +246,21 @@ public abstract class AbstractYamlConfigurationService implements ApplicationCon
     List<String> catalogPaths = getListOfStringsFromObject(ontologies.get(CATALOG_PATH.getLabel()));
     List<String> moduleIgnorePatterns = getListOfStringsFromObject(ontologies.get(MODULE_IGNORE_PATTERN.getLabel()));
     List<String> moduleToIgnore = getListOfStringsFromObject(ontologies.get(MODULE_TO_IGNORE.getLabel()));
-    boolean automaticCreationOfModules = 
-        getBooleanFromObject(ontologies.get(AUTOMATIC_CREATION_OF_MODULES.getLabel()), AUTOMATIC_CREATION_OF_MODULES_DEFULT);
-     List<String> downloadDirectory = getListOfStringsFromObject(ontologies.get(DOWNLOAD_DIRECTORY.getLabel()));
-     String moduleClassIri = getStringsFromObject(ontologies.get(MODULE_CLASS_IRI.getLabel()));
-     List<Pair> maturityLevelDefinition = getMaturityLevelDefinitionNameList(ontologies.get(MATURITY_LEVEL_DEFINITION.getLabel()));
+    boolean automaticCreationOfModules =
+        getBooleanFromObject(ontologies.get(AUTOMATIC_CREATION_OF_MODULES.getLabel()),
+            AUTOMATIC_CREATION_OF_MODULES_DEFULT);
+    List<String> downloadDirectory = getListOfStringsFromObject(ontologies.get(DOWNLOAD_DIRECTORY.getLabel()));
+    String moduleClassIri = getStringsFromObject(
+        ontologies.get(MODULE_CLASS_IRI.getLabel()),
+        ontologiesConfig.getModuleClassIri());
+    List<Pair> maturityLevelDefinition = getMaturityLevelDefinitionNameList(
+        ontologies.get(MATURITY_LEVEL_DEFINITION.getLabel()));
+    String maturityLevelProperty = getStringsFromObject(
+        ontologies.get(MATURITY_LEVEL_PROPERTY.getLabel()),
+        ontologiesConfig.getMaturityLevelProperty());
 
     return new OntologiesConfig(urls, paths, catalogPaths, downloadDirectory, zips, moduleIgnorePatterns,
-        moduleToIgnore, maturityLevelDefinition, automaticCreationOfModules, moduleClassIri);
+        moduleToIgnore, maturityLevelDefinition, automaticCreationOfModules, moduleClassIri, maturityLevelProperty);
   }
 
   protected IntegrationsConfig handleIntegrationsConfig(List<Map<String, Object>> integrationsList) {
@@ -269,7 +276,7 @@ public abstract class AbstractYamlConfigurationService implements ApplicationCon
 
       if (integrationId == null || integrationUrl == null || integrationAccessToken == null) {
         LOGGER.error("Missing data while reading integrations config: "
-            + "integrationId={}, integrationUrl={}, integrationAccessToken=[----]",
+                + "integrationId={}, integrationUrl={}, integrationAccessToken=[----]",
             integrationId, integrationUrl);
         continue;
       }
@@ -408,9 +415,16 @@ public abstract class AbstractYamlConfigurationService implements ApplicationCon
   }
 
   private String getStringsFromObject(Object stringAsObject) {
-    if (stringAsObject!=null) {
+    if (stringAsObject != null) {
       return stringAsObject.toString();
     }
     return null;
+  }
+
+  private String getStringsFromObject(Object stringAsObject, String defaultValue) {
+    if (stringAsObject != null) {
+      return stringAsObject.toString();
+    }
+    return defaultValue;
   }
 }

--- a/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/service/YamlFileBasedConfigurationService.java
+++ b/onto-viewer-config-loader/src/main/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/service/YamlFileBasedConfigurationService.java
@@ -264,7 +264,9 @@ public class YamlFileBasedConfigurationService extends AbstractYamlConfiguration
               break;
             }
             case ONTOLOGIES: {
-              OntologiesConfig ontologiesConfig = handleOntologies(configMap);
+              OntologiesConfig ontologiesConfig = handleOntologyConfig(
+                  configMap,
+                  configurationDataCandidate.getOntologiesConfig());
               configurationDataCandidate.setOntologiesConfig(ontologiesConfig);
 
               if (catalogPath != null && !catalogPath.isBlank()) {

--- a/onto-viewer-config-loader/src/main/resources/default_ontology_config.yaml
+++ b/onto-viewer-config-loader/src/main/resources/default_ontology_config.yaml
@@ -9,3 +9,4 @@ ontologies:
       label: 'Provisional'
     - iri: 'https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/Informative'
       label: 'Informative'
+  maturity_level_property: 'https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/hasMaturityLevel'

--- a/onto-viewer-config-loader/src/test/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/service/YamlFileBasedConfigurationServiceTest.java
+++ b/onto-viewer-config-loader/src/test/java/org/edmcouncil/spec/ontoviewer/configloader/configuration/service/YamlFileBasedConfigurationServiceTest.java
@@ -141,7 +141,7 @@ class YamlFileBasedConfigurationServiceTest {
   }
 
   @Test
-  void shouldHaveConfigMixedBothFromDefaultsAndCustomOntologiesConfig() {
+  void shouldHaveConfigMixedBothFromDefaultsAndCustomOntologiesConfigWithMissingCustomConfigs() {
     var fileSystemManager = prepareFileSystem();
     prepareTestConfiguration("/configuration_yaml/ontologies_config1.yaml");
 
@@ -169,6 +169,9 @@ class YamlFileBasedConfigurationServiceTest {
     assertEquals("ontologies/catalog-v001.xml", ontologiesConfig.getCatalogPaths().get(0));
     assertEquals("^(About|Metadata).*", ontologiesConfig.getModuleIgnorePatterns().get(0));
     assertEquals("http://example.com/ontology", ontologiesConfig.getModuleToIgnore().get(0));
+    assertEquals(
+        "https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/hasMaturityLevel",
+        ontologiesConfig.getMaturityLevelProperty());
 
     // Search Config
     assertEquals(2, configurationData.getSearchConfig().getSearchDescriptions().size());
@@ -176,6 +179,52 @@ class YamlFileBasedConfigurationServiceTest {
     assertTrue(configurationData.getSearchConfig().isReindexOnStart());
     assertEquals(6, configurationData.getSearchConfig().getFindProperties().size());
     
+    // Application Config
+    assertFalse(configurationData.getApplicationConfig().isDisplayCopyright());
+    assertFalse(configurationData.getApplicationConfig().isDisplayLicense());
+    assertEquals("http://purl.org/dc/terms/license", configurationData.getApplicationConfig().getLicense().get(0));
+    assertEquals("http://www.omg.org/techprocess/ab/SpecificationMetadata/copyright", configurationData.getApplicationConfig().getCopyright().get(0));
+  }
+
+  @Test
+  void shouldHaveConfigMixedBothFromDefaultsAndCustomOntologiesConfig() {
+    var fileSystemManager = prepareFileSystem();
+    prepareTestConfiguration("/configuration_yaml/ontologies_config2.yaml");
+
+    var yamlConfigurationService = new YamlFileBasedConfigurationService(fileSystemManager);
+    yamlConfigurationService.init();
+    var configurationData = yamlConfigurationService.getConfigurationData();
+
+    // Groups Config
+    assertEquals(2, configurationData.getGroupsConfig().getPriorityList().size());
+    assertEquals(5, configurationData.getGroupsConfig().getGroups().size());
+
+    // Label Config
+    assertTrue(configurationData.getLabelConfig().isDisplayLabel());
+    assertEquals(LabelPriority.USER_DEFINED, configurationData.getLabelConfig().getLabelPriority());
+    assertFalse(configurationData.getLabelConfig().isForceLabelLang());
+    assertEquals("en", configurationData.getLabelConfig().getLabelLang());
+    assertEquals(MissingLanguageAction.FIRST, configurationData.getLabelConfig().getMissingLanguageAction());
+    assertEquals(45, configurationData.getLabelConfig().getDefaultNames().size());
+
+    // Ontology Config
+    var ontologiesConfig = configurationData.getOntologiesConfig();
+    assertEquals("foo/bar/my_dir", ontologiesConfig.getPaths().get(0));
+    assertEquals("foo/my_ontology.rdf", ontologiesConfig.getPaths().get(1));
+    assertEquals("http://example.com", ontologiesConfig.getUrls().get(0));
+    assertEquals("ontologies/catalog-v001.xml", ontologiesConfig.getCatalogPaths().get(0));
+    assertEquals("^(About|Metadata).*", ontologiesConfig.getModuleIgnorePatterns().get(0));
+    assertEquals("http://example.com/ontology", ontologiesConfig.getModuleToIgnore().get(0));
+    assertEquals(
+        "https://example.com/test/hasMaturityLevel",
+        ontologiesConfig.getMaturityLevelProperty());
+
+    // Search Config
+    assertEquals(2, configurationData.getSearchConfig().getSearchDescriptions().size());
+    assertEquals(3, configurationData.getSearchConfig().getFuzzyDistance());
+    assertTrue(configurationData.getSearchConfig().isReindexOnStart());
+    assertEquals(6, configurationData.getSearchConfig().getFindProperties().size());
+
     // Application Config
     assertFalse(configurationData.getApplicationConfig().isDisplayCopyright());
     assertFalse(configurationData.getApplicationConfig().isDisplayLicense());

--- a/onto-viewer-config-loader/src/test/resources/configuration_yaml/ontologies_config2.yaml
+++ b/onto-viewer-config-loader/src/test/resources/configuration_yaml/ontologies_config2.yaml
@@ -1,0 +1,12 @@
+ontologies:
+  source:
+    - url: http://example.com
+    - path: foo/bar/my_dir
+    - path: foo/my_ontology.rdf
+  catalog_path:
+    - ontologies/catalog-v001.xml
+  module_ignore_pattern:
+    - '^(About|Metadata).*'
+  module_to_ignore:
+    - 'http://example.com/ontology'
+  maturity_level_property: 'https://example.com/test/hasMaturityLevel'

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/DetailsManager.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/DetailsManager.java
@@ -127,9 +127,7 @@ public class DetailsManager {
         .getToolkitConfig()
         .isLocationInModulesEnabled();
     if (locationInModulesEnabled) {
-      result.setLocationInModules(
-          moduleHelper.getElementLocationInModules(
-              entityIri.getIRIString()));
+      result.setLocationInModules(moduleHelper.getElementLocationInModules(entityIri));
     }
     result.setVersionIri(versionIriHandler.getVersionIri(entityIri));
     result.setMaturityLevel(moduleHelper.getMaturityLevel(entityIri));
@@ -164,7 +162,7 @@ public class DetailsManager {
     }
     result.setDeprecated(deprecatedHandler.getDeprecatedForEntity(iri));
     result.setVersionIri(versionIriHandler.getVersionIri(iri));
-    return setGroupedDetailsIfEnabled(iriString, result);
+    return setGroupedDetailsIfEnabled(iri, result);
   }
 
   public List<OntologyModule> getAllModulesData() {
@@ -184,15 +182,15 @@ public class DetailsManager {
     }
     resultDetails.setDeprecated(deprecatedHandler.getDeprecatedForEntity(iri));
     resultDetails.setVersionIri(versionIriHandler.getVersionIri(iri));
-    return setGroupedDetailsIfEnabled(iriString, resultDetails);
+    return setGroupedDetailsIfEnabled(iri, resultDetails);
   }
 
-  private OwlDetails setGroupedDetailsIfEnabled(String iriString, OwlListDetails result) {
+  private OwlDetails setGroupedDetailsIfEnabled(IRI iri, OwlListDetails result) {
     var locationInModulesEnabled = applicationConfigurationService.getConfigurationData()
         .getToolkitConfig()
         .isLocationInModulesEnabled();
     if (locationInModulesEnabled) {
-      result.setLocationInModules(moduleHelper.getElementLocationInModules(iriString));
+      result.setLocationInModules(moduleHelper.getElementLocationInModules(iri));
     }
 
     ConfigurationData configurationData = applicationConfigurationService.getConfigurationData();

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/MaturityLevelHandler.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/MaturityLevelHandler.java
@@ -1,0 +1,157 @@
+package org.edmcouncil.spec.ontoviewer.core.ontology.data.handler;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.edmcouncil.spec.ontoviewer.configloader.configuration.service.ApplicationConfigurationService;
+import org.edmcouncil.spec.ontoviewer.core.ontology.OntologyManager;
+import org.edmcouncil.spec.ontoviewer.core.ontology.data.handler.maturity.MaturityLevel;
+import org.edmcouncil.spec.ontoviewer.core.ontology.data.handler.maturity.MaturityLevelFactory;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAnnotation;
+import org.semanticweb.owlapi.model.OWLAnnotationProperty;
+import org.semanticweb.owlapi.model.OWLEntity;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.parameters.Imports;
+import org.semanticweb.owlapi.search.EntitySearcher;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MaturityLevelHandler {
+
+  private final ApplicationConfigurationService applicationConfigurationService;
+  private final OntologyManager ontologyManager;
+  private final MaturityLevelFactory maturityLevelFactory;
+
+  private OWLAnnotationProperty maturityLevelAnnotationProperty;
+
+  public MaturityLevelHandler(ApplicationConfigurationService applicationConfigurationService,
+      OntologyManager ontologyManager,
+      MaturityLevelFactory maturityLevelFactory) {
+    this.applicationConfigurationService = applicationConfigurationService;
+    this.ontologyManager = ontologyManager;
+    this.maturityLevelFactory = maturityLevelFactory;
+  }
+
+  public MaturityLevel getMaturityLevelForElement(IRI entityIri) {
+    Optional<OWLEntity> entityOptional = ontologyManager.getOntology()
+        .signature(Imports.INCLUDED)
+        .filter(c -> c.getIRI().equals(entityIri))
+        .findFirst();
+
+    // Check if the entityOptional has its own level of maturity
+    if (entityOptional.isEmpty()) {
+      return maturityLevelFactory.notSet();
+    }
+
+    OWLEntity entity = entityOptional.get();
+
+    var maturityLevelOptional = getMaturityLevelForEntity(entity);
+    if (maturityLevelOptional.isPresent() && !maturityLevelOptional.get().equals(maturityLevelFactory.notSet())) {
+      return maturityLevelOptional.get();
+    }
+
+    maturityLevelOptional = getMaturityLevelForEntityFromOntology(entity);
+    if (maturityLevelOptional.isPresent() && !maturityLevelOptional.get().equals(maturityLevelFactory.notSet())) {
+      return maturityLevelOptional.get();
+    }
+
+    return maturityLevelFactory.notSet();
+  }
+
+  public Optional<MaturityLevel> getMaturityLevelForParticularOntology(OWLOntology ontology) {
+    var levelString = maturityLevelFactory.getMaturityLevels()
+        .stream()
+        .map(MaturityLevel::getIri)
+        .collect(Collectors.toSet());
+    for (OWLAnnotation annotation : ontology.annotationsAsList()) {
+      var annotationValue = annotation.annotationValue();
+
+      if (annotationValue.isIRI()
+          && annotationValue.asIRI().isPresent()
+          && levelString.contains(annotationValue.asIRI().get().getIRIString())) {
+        String annotationIri = annotationValue.asIRI().get().toString();
+        return maturityLevelFactory.getByIri(annotationIri);
+      }
+    }
+
+    return Optional.empty();
+  }
+
+  private Optional<MaturityLevel> getMaturityLevelForEntity(OWLEntity entity) {
+    var maturityLevelProperties = EntitySearcher.getAnnotations(
+            entity,
+            ontologyManager.getOntologyWithImports(),
+            maturityLevelAnnotationProperty)
+        .collect(Collectors.toList());
+
+    if (maturityLevelProperties.isEmpty()) {
+      return Optional.empty();
+    }
+
+    MaturityLevel maturityLevel = null;
+
+    for (OWLAnnotation maturityLevelProperty : maturityLevelProperties) {
+      if (maturityLevelProperty.getValue().isIRI()) {
+        var maturityLevelPropertyValueIri = maturityLevelProperty.getValue().asIRI().get();
+        var maturityLevelOptional = maturityLevelFactory.getMaturityLevels()
+            .stream()
+            .filter(maturityLevelCandidate ->
+                maturityLevelCandidate.getIri().equals(maturityLevelPropertyValueIri.getIRIString()))
+            .findFirst();
+        if (maturityLevelOptional.isPresent()) {
+          maturityLevel = maturityLevelOptional.get();
+          break;
+        }
+      }
+    }
+
+    if (maturityLevel != null) {
+      return Optional.of(maturityLevel);
+    }
+
+    return Optional.empty();
+  }
+
+  private Optional<MaturityLevel> getMaturityLevelForEntityFromOntology(OWLEntity entity) {
+    List<OWLOntology> ontologies = ontologyManager.getOntologyWithImports().collect(Collectors.toList());
+    for (OWLOntology ontology : ontologies) {
+      boolean entityInOntologyPresent = ontology.entitiesInSignature(entity.getIRI(), Imports.EXCLUDED)
+          .findAny()
+          .isPresent();
+      if (entityInOntologyPresent) {
+        var maturityLevelProperties = ontology
+            .annotations(getMaturityLevelProperty())
+            .collect(Collectors.toList());
+
+        if (maturityLevelProperties.isEmpty()) {
+          break;
+        } else {
+          for (OWLAnnotation maturityLevelProperty : maturityLevelProperties) {
+            if (maturityLevelProperty.getValue().isIRI() && maturityLevelProperty.getValue().asIRI().isPresent()) {
+              var maturityLevelPropertyValueIri = maturityLevelProperty.getValue().asIRI().get();
+              var maturityLevelOptional =
+                  maturityLevelFactory.getMaturityLevel(maturityLevelPropertyValueIri.getIRIString());
+              if (maturityLevelOptional.isPresent()) {
+                return maturityLevelOptional;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return Optional.empty();
+  }
+
+  private OWLAnnotationProperty getMaturityLevelProperty() {
+    if (maturityLevelAnnotationProperty == null) {
+      String maturityLevelPropertyIriString =
+          applicationConfigurationService.getConfigurationData().getOntologiesConfig().getMaturityLevelProperty();
+      maturityLevelAnnotationProperty =
+          OWLManager.getOWLDataFactory().getOWLAnnotationProperty(IRI.create(maturityLevelPropertyIriString));
+    }
+    return maturityLevelAnnotationProperty;
+  }
+}

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/maturity/MaturityLevelFactory.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/maturity/MaturityLevelFactory.java
@@ -14,7 +14,8 @@ import org.springframework.stereotype.Component;
 public class MaturityLevelFactory {
 
   public static final MaturityLevel MIXED = new MaturityLevel("Mixed", "https://spec.edmcouncil.org/ontoviewer/Mixed");
-  public static final MaturityLevel NOT_SET = new MaturityLevel("Not Set", "https://spec.edmcouncil.org/ontoviewer/NotSet");
+  public static final MaturityLevel NOT_SET = new MaturityLevel("Not Set",
+      "https://spec.edmcouncil.org/ontoviewer/NotSet");
 
   private final ApplicationConfigurationService applicationConfigurationService;
   private List<MaturityLevel> maturityLevels = null;
@@ -39,8 +40,8 @@ public class MaturityLevelFactory {
     }
     return Optional.empty();
   }
-  
-    public Optional<MaturityLevel> getByLabel(String maturityLevelLabel) {
+
+  public Optional<MaturityLevel> getByLabel(String maturityLevelLabel) {
     for (MaturityLevel value : maturityLevels) {
       if (value.getLabel().equals(maturityLevelLabel)) {
         return Optional.of(value);
@@ -58,5 +59,12 @@ public class MaturityLevelFactory {
       }
     }
     return maturityLevels;
+  }
+
+  public Optional<MaturityLevel> getMaturityLevel(String candidateIriString) {
+    return getMaturityLevels()
+        .stream()
+        .filter(maturityLevelCandidate -> maturityLevelCandidate.getIri().equals(candidateIriString))
+        .findFirst();
   }
 }

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/module/ModuleHandler.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/module/ModuleHandler.java
@@ -22,6 +22,7 @@ import org.edmcouncil.spec.ontoviewer.core.model.module.OntologyModule;
 import org.edmcouncil.spec.ontoviewer.core.model.property.OwlDetailsProperties;
 import org.edmcouncil.spec.ontoviewer.core.model.property.OwlListElementIndividualProperty;
 import org.edmcouncil.spec.ontoviewer.core.ontology.OntologyManager;
+import org.edmcouncil.spec.ontoviewer.core.ontology.data.handler.MaturityLevelHandler;
 import org.edmcouncil.spec.ontoviewer.core.ontology.data.handler.individual.IndividualDataHelper;
 import org.edmcouncil.spec.ontoviewer.core.ontology.data.handler.maturity.MaturityLevel;
 import org.edmcouncil.spec.ontoviewer.core.ontology.data.handler.maturity.MaturityLevelFactory;
@@ -29,25 +30,20 @@ import org.edmcouncil.spec.ontoviewer.core.ontology.data.label.LabelProvider;
 import org.edmcouncil.spec.ontoviewer.core.ontology.factory.ViewerIdentifierFactory;
 import org.edmcouncil.spec.ontoviewer.core.utils.PathUtils;
 import org.semanticweb.owlapi.apibinding.OWLManager;
-import org.semanticweb.owlapi.model.EntityType;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLAnnotation;
 import org.semanticweb.owlapi.model.OWLAnnotationProperty;
 import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLDataFactory;
-import org.semanticweb.owlapi.model.OWLEntity;
 import org.semanticweb.owlapi.model.OWLNamedIndividual;
 import org.semanticweb.owlapi.model.OWLOntology;
 import org.semanticweb.owlapi.model.parameters.Imports;
 import org.semanticweb.owlapi.search.EntitySearcher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 @Service
 public class ModuleHandler {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(ModuleHandler.class);
   private static final String ONTOLOGY_IRI_GROUP_NAME = "ontologyIri";
   private static final Pattern ONTOLOGY_IRI_PATTERN = Pattern.compile("(?<ontologyIri>.*\\/)[^/]+$");
   private static final String HAS_PART_IRI = "http://purl.org/dc/terms/hasPart";
@@ -56,255 +52,38 @@ public class ModuleHandler {
       OwlType.INSTANCES.name().toLowerCase());
   private static final Pattern URL_PATTERN
       = Pattern.compile("^(https?|ftp|file)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]");
-  private final MaturityLevelFactory maturityLevelFactory;
   private final ApplicationConfigurationService applicationConfigurationService;
+  private final MaturityLevelFactory maturityLevelFactory;
   private final OntologyManager ontologyManager;
   private final IndividualDataHelper individualDataHelper;
   private final LabelProvider labelProvider;
   private final OWLAnnotationProperty hasPartAnnotation;
+  private final MaturityLevelHandler maturityLevelHandler;
+
   // Cache for ontologies' maturity level
   private final Map<IRI, MaturityLevel> maturityLevelsCache = new ConcurrentHashMap<>();
-  private  Set<IRI> ontologiesToIgnoreWhenGeneratingModules;
-  private  Set<Pattern> ontologyModuleIgnorePatterns;
+
+  private Set<IRI> ontologiesToIgnoreWhenGeneratingModules;
+  private Set<Pattern> ontologyModuleIgnorePatterns;
   private String moduleClassIri;
-  private  boolean automaticCreationOfModules;
+  private boolean automaticCreationOfModules;
   private List<OntologyModule> modules;
   private Map<IRI, OntologyModule> modulesMap;
 
-  public ModuleHandler(OntologyManager ontologyManager,
+  public ModuleHandler(ApplicationConfigurationService applicationConfigurationService,
+      OntologyManager ontologyManager,
       IndividualDataHelper individualDataHelper,
       LabelProvider labelProvider,
-      ApplicationConfigurationService applicationConfigurationService,
-      MaturityLevelFactory maturityLevelFactory) {
+      MaturityLevelFactory maturityLevelFactory,
+      MaturityLevelHandler maturityLevelHandler) {
+    this.applicationConfigurationService = applicationConfigurationService;
     this.ontologyManager = ontologyManager;
     this.individualDataHelper = individualDataHelper;
     this.labelProvider = labelProvider;
     this.maturityLevelFactory = maturityLevelFactory;
-    this.applicationConfigurationService = applicationConfigurationService;
+    this.maturityLevelHandler = maturityLevelHandler;
 
     this.hasPartAnnotation = OWLManager.getOWLDataFactory().getOWLAnnotationProperty(IRI.create(HAS_PART_IRI));
-  }
-
-  public List<OntologyModule> getModules() {
-    if (modules == null) {
-      var ontology = ontologyManager.getOntology();
-
-      modules = new ArrayList<>();
-
-      if (moduleClassIri != null) {
-        IRI moduleIri = IRI.create(moduleClassIri);
-        Optional<OWLClass> moduleClassOptional = ontology
-            .classesInSignature(Imports.INCLUDED)
-            .filter(c -> c.getIRI().equals(moduleIri))
-            .findFirst();
-
-        if (moduleClassOptional.isPresent()) {
-          OwlDetailsProperties<PropertyValue> moduleClass
-              = individualDataHelper.handleClassIndividuals(ontology, moduleClassOptional.get());
-
-          if (!moduleClass.getProperties().isEmpty()) {
-            Set<String> modulesIris = moduleClass.getProperties().get(INSTANCE_KEY)
-                .stream()
-                .map(OwlListElementIndividualProperty.class::cast)
-                .map(individualProperty -> individualProperty.getValue().getIri())
-                .collect(Collectors.toSet());
-
-            List<String> rootModulesIris = getRootModulesIris(modulesIris);
-
-            this.modules = prepareModuleObjects(rootModulesIris);
-            this.modules.forEach(this::checkAndCompleteMaturityLevel);
-          }
-        }
-      }
-      if (automaticCreationOfModules) {
-        addMissingModules(modules);
-      }
-
-      modulesMap = prepareModulesMap(modules);
-    }
-    return modules;
-  }
-
-  public List<String> getRootModulesIris(Set<String> modulesIris) {
-    Map<String, Integer> referenceCount = new LinkedHashMap<>();
-
-    modulesIris.forEach(moduleIri -> {
-      Set<String> subModules = getSubModules(IRI.create(moduleIri));
-      referenceCount.putIfAbsent(moduleIri, 0);
-
-      subModules.forEach(partModule -> {
-        int counter = referenceCount.getOrDefault(partModule, 0);
-        counter++;
-        referenceCount.put(partModule, counter);
-      });
-    });
-
-    return referenceCount.entrySet()
-        .stream()
-        .filter(moduleEntry -> moduleEntry.getValue() == 0)
-        .map(Entry::getKey)
-        .collect(Collectors.toList());
-  }
-
-  public List<String> getRootModulesIris(Set<String> modulesIriSet, OWLOntology ontology) {
-    Map<String, Integer> referenceCount = new LinkedHashMap<>();
-    modulesIriSet.forEach(moduleIri -> {
-      Set<String> hasPartModules = getHasPartElements(IRI.create(moduleIri), ontology);
-      referenceCount.putIfAbsent(moduleIri, 0);
-      hasPartModules.forEach(partModule -> {
-        Integer c = referenceCount.getOrDefault(partModule, 0);
-        c++;
-        referenceCount.put(partModule, c);
-      });
-    });
-
-    return referenceCount.entrySet()
-        .stream()
-        .filter(r -> r.getValue() == 0)
-        .map(Entry::getKey)
-        .collect(Collectors.toList());
-  }
-
-  private List<OntologyModule> getSubModules(String moduleIri) {
-    Set<String> hasPartModules = getSubModules(IRI.create(moduleIri));
-
-    return prepareModuleObjects(hasPartModules);
-  }
-
-  private List<OntologyModule> prepareModuleObjects(Collection<String> modulesIris) {
-    return modulesIris.stream()
-        .map(moduleIri -> {
-          OntologyModule module = new OntologyModule();
-          module.setIri(moduleIri);
-          module.setLabel(labelProvider.getLabelOrDefaultFragment(IRI.create(moduleIri)));
-          module.setMaturityLevel(getMaturityLevelForOntology(IRI.create(moduleIri)));
-          module.setSubModule(getSubModules(moduleIri));
-          return module;
-        })
-        .sorted()
-        .collect(Collectors.toList());
-  }
-
-  public Set<String> getSubModules(IRI moduleIri) {
-    var ontology = ontologyManager.getOntology();
-
-    Optional<OWLNamedIndividual> individual = ontology
-        .individualsInSignature(Imports.INCLUDED)
-        .filter(c -> c.getIRI().equals(moduleIri))
-        .findFirst();
-
-    if (individual.isEmpty()) {
-      return new HashSet<>(0);
-    }
-
-    return EntitySearcher
-        .getAnnotations(
-            individual.get(),
-            ontology.importsClosure(),
-            hasPartAnnotation)
-        .map(owlAnnotation -> owlAnnotation.annotationValue().toString())
-        .collect(Collectors.toSet());
-  }
-
-  public MaturityLevel getMaturityLevelForModule(IRI moduleIri) {
-    OntologyModule ontologyModule = modulesMap.get(moduleIri);
-    if (ontologyModule != null) {
-      return ontologyModule.getMaturityLevel();
-    }
-    return maturityLevelFactory.notSet();
-  }
-
-  public MaturityLevel getMaturityLevelForElement(IRI entityIri) {
-    //check if the searched maturity level belongs to the module
-    OntologyModule ontologyModule = modulesMap.get(entityIri);
-    if (ontologyModule != null) {
-      return ontologyModule.getMaturityLevel();
-    }
-    var ontologies = ontologyManager.getOntologyWithImports();
-
-    for (OWLOntology ontology : ontologies.collect(Collectors.toSet())) {
-      
-      if(ontology.getOntologyID().getOntologyIRI().isPresent()
-          && ontology.getOntologyID().getOntologyIRI().get().equals(entityIri)){
-        var maturityLevelOptional = getMaturityLevelForParticularOntology(ontology);
-        if (maturityLevelOptional.isPresent()) {
-          maturityLevelsCache.put(entityIri, maturityLevelOptional.get());
-          if(!maturityLevelOptional.get().equals(maturityLevelFactory.notSet())){
-            return maturityLevelOptional.get();
-          }
-        }
-      }
-
-      Optional<OWLEntity> entity = ontology
-        .signature(Imports.INCLUDED)
-        .filter(c -> c.getIRI().equals(entityIri))
-        .findFirst();
-    
-      //check if the entity has its own level of maturity  
-      if (entity.isPresent()){
-        var maturityLevelOptional =  getMaturityLevelForEntity(entity);
-        if (maturityLevelOptional.isPresent() 
-            && !maturityLevelOptional.get().equals(maturityLevelFactory.notSet())) {
-          return maturityLevelOptional.get();
-        }
-      }
-    }
-    
-    //in this case we can extract maturity level from ontology
-    IRI ontologyIri = getOntologyIri(entityIri);
-    if (ontologyIri != null) {
-      return getMaturityLevelForModule(ontologyIri);
-    }
-    return maturityLevelFactory.notSet();
-  }
-
-  private Optional<MaturityLevel> getMaturityLevelForEntity(Optional<OWLEntity> entity) {
-    
-    var ontologies = ontologyManager.getOntologyWithImports();
-    Set<OWLAnnotation> annotationsInEntity = new HashSet<>();
-    
-    for (OWLOntology owlOntology : ontologies.collect(Collectors.toSet())) {
-      var annotationsTmp = EntitySearcher
-            .getAnnotations(entity.get(), owlOntology).collect(Collectors.toSet());
-      annotationsInEntity.addAll(annotationsTmp);
-      //if (!annotationsInEntity.isEmpty()) break;
-    }
-    var levelStringIri = maturityLevelFactory.getMaturityLevels()
-            .stream()
-            .map(maturityLevel -> maturityLevel.getIri())
-            .collect(Collectors.toSet());
-    var levelStringLabels = maturityLevelFactory.getMaturityLevels()
-            .stream()
-            .map(maturityLevel -> maturityLevel.getLabel())
-            .collect(Collectors.toSet());
-    
-    for (OWLAnnotation annotation : annotationsInEntity) {
-      var annotationValue = annotation.annotationValue();
-      
-      if(annotationValue.isLiteral()
-              && annotationValue.asLiteral().isPresent()
-              && annotationValue.asLiteral().get().isLiteral()
-              && levelStringLabels.contains(annotationValue.asLiteral().get().getLiteral())){
-        
-        String maturityLabel = annotationValue.asLiteral().get().getLiteral();
-        var maturityLvlOptional = maturityLevelFactory.getByLabel(maturityLabel);
-         if (maturityLvlOptional.isPresent()) {
-          return maturityLvlOptional;
-        }
-         
-      } else if (annotationValue.isIRI()
-              && annotationValue.asIRI().isPresent()
-              && levelStringIri.contains(annotationValue.asIRI().get().getIRIString())) {
-        
-        String maturityiri = annotationValue.asIRI().get().toString();
-        var maturityLvlOptional = maturityLevelFactory.getByIri(maturityiri);
-        if (maturityLvlOptional.isPresent()) {
-          return maturityLvlOptional;
-        }
-      }
-      
-    }
-    return Optional.empty();
   }
 
   public void refreshModulesHandlerData() {
@@ -332,29 +111,137 @@ public class ModuleHandler {
         .getConfigurationData()
         .getOntologiesConfig()
         .getModuleClassIri();
+
     // If modules is empty is auto generated again while get
     getModules();
   }
 
-  private MaturityLevel getMaturityLevelForOntology(IRI ontologyIri) {
-    if (!maturityLevelsCache.containsKey(ontologyIri)) {
-      var ontologies = ontologyManager.getOntologyWithImports().collect(Collectors.toSet());
+  public List<OntologyModule> getModules() {
+    if (modules == null) {
+      var ontology = ontologyManager.getOntology();
 
-      for (OWLOntology ontology : ontologies) {
-        var currentOntologyIri = ontology.getOntologyID().getOntologyIRI();
-        if (currentOntologyIri.isPresent() && currentOntologyIri.get().equals(ontologyIri)) {
-          var maturityLevelOptional = getMaturityLevelForParticularOntology(ontology);
-          if (maturityLevelOptional.isPresent()) {
-            maturityLevelsCache.put(ontologyIri, maturityLevelOptional.get());
-            break;
+      modules = new ArrayList<>();
+
+      if (moduleClassIri != null) {
+        IRI moduleIri = IRI.create(moduleClassIri);
+        Optional<OWLClass> moduleClassOptional = ontology
+            .classesInSignature(Imports.INCLUDED)
+            .filter(c -> c.getIRI().equals(moduleIri))
+            .findFirst();
+
+        if (moduleClassOptional.isPresent()) {
+          OwlDetailsProperties<PropertyValue> moduleClass =
+              individualDataHelper.handleClassIndividuals(ontology, moduleClassOptional.get());
+
+          if (!moduleClass.getProperties().isEmpty()) {
+            Set<String> modulesIris = moduleClass.getProperties().get(INSTANCE_KEY)
+                .stream()
+                .map(OwlListElementIndividualProperty.class::cast)
+                .map(individualProperty -> individualProperty.getValue().getIri())
+                .collect(Collectors.toSet());
+
+            List<String> rootModulesIris = getRootModulesIris(modulesIris);
+
+            this.modules = prepareModuleObjects(rootModulesIris);
+            this.modules.forEach(this::checkAndCompleteMaturityLevel);
           }
         }
       }
+      if (automaticCreationOfModules) {
+        addMissingModules(modules);
+      }
+
+      modulesMap = prepareModulesMap(modules);
     }
 
-    return maturityLevelsCache.computeIfAbsent(
-        ontologyIri,
-        iri -> maturityLevelFactory.notSet());
+    return modules;
+  }
+
+  public List<String> getRootModulesIris(Set<String> modulesIriSet, OWLOntology ontology) {
+    Map<String, Integer> referenceCount = new LinkedHashMap<>();
+    modulesIriSet.forEach(moduleIri -> {
+      Set<String> hasPartModules = getHasPartElements(IRI.create(moduleIri), ontology);
+      referenceCount.putIfAbsent(moduleIri, 0);
+
+      hasPartModules.forEach(partModule -> {
+        Integer counter = referenceCount.getOrDefault(partModule, 0);
+        counter++;
+        referenceCount.put(partModule, counter);
+      });
+    });
+
+    return referenceCount.entrySet()
+        .stream()
+        .filter(moduleEntry -> moduleEntry.getValue() == 0)
+        .map(Entry::getKey)
+        .collect(Collectors.toList());
+  }
+
+  private List<String> getRootModulesIris(Set<String> modulesIris) {
+    Map<String, Integer> referenceCount = new LinkedHashMap<>();
+
+    modulesIris.forEach(moduleIri -> {
+      Set<String> subModules = getSubModules(IRI.create(moduleIri));
+      referenceCount.putIfAbsent(moduleIri, 0);
+
+      subModules.forEach(partModule -> {
+        int counter = referenceCount.getOrDefault(partModule, 0);
+        counter++;
+        referenceCount.put(partModule, counter);
+      });
+    });
+
+    return referenceCount.entrySet()
+        .stream()
+        .filter(moduleEntry -> moduleEntry.getValue() == 0)
+        .map(Entry::getKey)
+        .collect(Collectors.toList());
+  }
+
+  private List<OntologyModule> getSubModules(String moduleIri) {
+    Set<String> hasPartModules = getSubModules(IRI.create(moduleIri));
+
+    return prepareModuleObjects(hasPartModules);
+  }
+
+  private List<OntologyModule> prepareModuleObjects(Collection<String> modulesIris) {
+    return modulesIris.stream()
+        .map(moduleIri -> {
+          OntologyModule module = new OntologyModule();
+          module.setIri(moduleIri);
+          module.setLabel(labelProvider.getLabelOrDefaultFragment(IRI.create(moduleIri)));
+          module.setMaturityLevel(getMaturityLevelForOntology(IRI.create(moduleIri)));
+          module.setSubModule(getSubModules(moduleIri));
+          return module;
+        })
+        .sorted()
+        .collect(Collectors.toList());
+  }
+
+  private Set<String> getSubModules(IRI moduleIri) {
+    var ontology = ontologyManager.getOntology();
+
+    Optional<OWLNamedIndividual> individual = ontology
+        .individualsInSignature(Imports.INCLUDED)
+        .filter(c -> c.getIRI().equals(moduleIri))
+        .findFirst();
+
+    return individual.map(owlNamedIndividual -> EntitySearcher
+            .getAnnotations(
+                owlNamedIndividual,
+                ontology.importsClosure(),
+                hasPartAnnotation)
+            .map(owlAnnotation -> owlAnnotation.annotationValue().toString())
+            .collect(Collectors.toSet()))
+        .orElseGet(() -> new HashSet<>(0));
+  }
+
+  public MaturityLevel getMaturityLevelForModule(IRI moduleIri) {
+    OntologyModule ontologyModule = modulesMap.get(moduleIri);
+    if (ontologyModule != null) {
+      return ontologyModule.getMaturityLevel();
+    }
+    return maturityLevelFactory.notSet();
   }
 
   public IRI getOntologyIri(IRI elementIri) {
@@ -371,23 +258,26 @@ public class ModuleHandler {
     return elementIri;
   }
 
-  private Optional<MaturityLevel> getMaturityLevelForParticularOntology(OWLOntology ontology) {
-    var levelString = maturityLevelFactory.getMaturityLevels()
-        .stream()
-        .map(MaturityLevel::getIri)
-        .collect(Collectors.toSet());
-    for (OWLAnnotation annotation : ontology.annotationsAsList()) {
-      var annotationValue = annotation.annotationValue();
+  public MaturityLevel getMaturityLevelForEntity(IRI entityIri) {
+    MaturityLevel maturityLevel = maturityLevelHandler.getMaturityLevelForElement(entityIri);
 
-      if (annotationValue.isIRI()
-          && annotationValue.asIRI().isPresent()
-          && levelString.contains(annotationValue.asIRI().get().getIRIString())) {
-        String annotationIri = annotationValue.asIRI().get().toString();
-        return maturityLevelFactory.getByIri(annotationIri);
-      }
+    if (maturityLevel != MaturityLevelFactory.NOT_SET) {
+      return maturityLevel;
     }
 
-    return Optional.empty();
+    // Check if the searched maturity level belongs to the module
+    OntologyModule ontologyModule = modulesMap.get(entityIri);
+    if (ontologyModule != null) {
+      return ontologyModule.getMaturityLevel();
+    }
+
+    // In this case we can extract maturity level from ontology
+    IRI ontologyIri = getOntologyIri(entityIri);
+    if (ontologyIri != null) {
+      return getMaturityLevelForModule(ontologyIri);
+    }
+
+    return maturityLevelFactory.notSet();
   }
 
   private void checkAndCompleteMaturityLevel(OntologyModule module) {
@@ -458,10 +348,15 @@ public class ModuleHandler {
           module.setIri(ontologyIri.toString());
           module.setLabel(labelProvider.getLabelOrDefaultFragment(ontologyIri));
           module.setSubModule(new ArrayList<>());
-          module.setMaturityLevel(getMaturityLevelForOntology(ontologyIri));
-          if ("".equals(module.getMaturityLevel().getLabel())) {
+
+          Optional<MaturityLevel> maturityLevelOptional =
+              maturityLevelHandler.getMaturityLevelForParticularOntology(owlOntology);
+          if (maturityLevelOptional.isPresent()) {
+            module.setMaturityLevel(maturityLevelOptional.get());
+          } else {
             module.setMaturityLevel(maturityLevelFactory.notSet());
           }
+
           return module;
         })
         .filter(ontologyModule -> !ontologyModule.getLabel().isEmpty())
@@ -552,5 +447,26 @@ public class ModuleHandler {
     }
 
     return result;
+  }
+
+  private MaturityLevel getMaturityLevelForOntology(IRI ontologyIri) {
+    if (!maturityLevelsCache.containsKey(ontologyIri)) {
+      var ontologies = ontologyManager.getOntologyWithImports().collect(Collectors.toSet());
+
+      for (OWLOntology ontology : ontologies) {
+        var currentOntologyIri = ontology.getOntologyID().getOntologyIRI();
+        if (currentOntologyIri.isPresent() && currentOntologyIri.get().equals(ontologyIri)) {
+          var maturityLevelOptional = maturityLevelHandler.getMaturityLevelForParticularOntology(ontology);
+          if (maturityLevelOptional.isPresent()) {
+            maturityLevelsCache.put(ontologyIri, maturityLevelOptional.get());
+            break;
+          }
+        }
+      }
+    }
+
+    return maturityLevelsCache.computeIfAbsent(
+        ontologyIri,
+        iri -> maturityLevelFactory.notSet());
   }
 }

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/module/ModuleHelper.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/module/ModuleHelper.java
@@ -23,16 +23,11 @@ public class ModuleHelper {
   }
 
   public MaturityLevel getMaturityLevel(IRI iri) {
-    return moduleHandler.getMaturityLevelForElement(iri);
+    return moduleHandler.getMaturityLevelForEntity(iri);
   }
 
   public List<OntologyModule> getAllModules() {
     return moduleHandler.getModules();
-  }
-
-  public List<String> getElementLocationInModules(String iriString) { // TODO use 'IRI'
-    LOG.debug("[Data Handler] Handle location for element {}", iriString);
-    return getElementLocationInModules(IRI.create(iriString));
   }
 
   public List<String> getElementLocationInModules(IRI elementIri) {

--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/stats/OntologyStatsManager.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/stats/OntologyStatsManager.java
@@ -39,8 +39,9 @@ public class OntologyStatsManager {
   private final ModuleHandler moduleHandler;
   private final IndividualDataHelper individualDataHandler;
   private final LabelProvider labelProvider;
-  private final String moduleClassIri;
+  private final ApplicationConfigurationService applicationConfigurationService;
 
+  private String moduleClassIri;
   private OntologyStatsMapped ontologyStatsMapped;
 
   public OntologyStatsManager(ModuleHandler moduleHandler,
@@ -50,10 +51,7 @@ public class OntologyStatsManager {
     this.moduleHandler = moduleHandler;
     this.individualDataHandler = individualDataHandler;
     this.labelProvider = labelProvider;
-    this.moduleClassIri = applicationConfigurationService
-        .getConfigurationData()
-        .getOntologiesConfig()
-        .getModuleClassIri();
+    this.applicationConfigurationService = applicationConfigurationService;
   }
 
   public OntologyStatsMapped getOntologyStats() {
@@ -165,14 +163,23 @@ public class OntologyStatsManager {
     osm.setStats(stats);
 
     ontologyStatsMapped = osm;
-
   }
 
   private Optional<OWLClass> getModuleClazz(OWLOntology ontology) {
-    IRI moduleIri = IRI.create(moduleClassIri);
+    IRI moduleIri = IRI.create(getModuleClassIri());
     return ontology
         .classesInSignature(Imports.INCLUDED)
         .filter(c -> c.getIRI().equals(moduleIri))
         .findFirst();
+  }
+
+  private String getModuleClassIri() {
+    if (moduleClassIri == null) {
+      this.moduleClassIri = applicationConfigurationService
+          .getConfigurationData()
+          .getOntologiesConfig()
+          .getModuleClassIri();
+    }
+    return moduleClassIri;
   }
 }

--- a/onto-viewer-core/src/test/resources/ontology/maturity_level.rdf
+++ b/onto-viewer-core/src/test/resources/ontology/maturity_level.rdf
@@ -1,0 +1,201 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://www.example.com/modules/"
+     xml:base="http://www.example.com/modules/"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:terms="http://purl.org/dc/terms/"
+     xmlns:AnnotationVocabulary="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/">
+    <owl:Ontology rdf:about="http://www.example.com/modules">
+        <AnnotationVocabulary:hasMaturityLevel rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/Informative"/>
+    </owl:Ontology>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.org/dc/terms/hasPart -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/hasPart"/>
+    
+
+
+    <!-- https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/hasMaturityLevel -->
+
+    <owl:AnnotationProperty rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/hasMaturityLevel"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.example.com/modules/ClassA -->
+
+    <owl:Class rdf:about="http://www.example.com/modules/ClassA">
+        <AnnotationVocabulary:hasMaturityLevel rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/Release"/>
+    </owl:Class>
+    
+
+
+    <!-- http://www.example.com/modules/ClassB -->
+
+    <owl:Class rdf:about="http://www.example.com/modules/ClassB"/>
+    
+
+
+    <!-- http://www.omg.org/techprocess/ab/SpecificationMetadata/Module -->
+
+    <owl:Class rdf:about="http://www.omg.org/techprocess/ab/SpecificationMetadata/Module"/>
+    
+
+
+    <!-- https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/MaturityLevel -->
+
+    <owl:Class rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/MaturityLevel"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Individuals
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.example.com/modules/ModuleA -->
+
+    <owl:NamedIndividual rdf:about="http://www.example.com/modules/ModuleA">
+        <rdf:type rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/Module"/>
+        <terms:hasPart rdf:resource="http://www.example.com/modules/ModuleA_1"/>
+        <terms:hasPart rdf:resource="http://www.example.com/modules/ModuleA_2"/>
+        <terms:hasPart rdf:resource="http://www.example.com/modules/ModuleA_3"/>
+        <AnnotationVocabulary:hasMaturityLevel rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/Provisional"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.example.com/modules/ModuleA_1 -->
+
+    <owl:NamedIndividual rdf:about="http://www.example.com/modules/ModuleA_1">
+        <rdf:type rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/Module"/>
+        <terms:hasPart rdf:resource="http://www.example.com/modules/ModuleA_1_a"/>
+        <AnnotationVocabulary:hasMaturityLevel rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/Provisional"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.example.com/modules/ModuleA_1_a -->
+
+    <owl:NamedIndividual rdf:about="http://www.example.com/modules/ModuleA_1_a">
+        <rdf:type rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/Module"/>
+        <AnnotationVocabulary:hasMaturityLevel rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/Provisional"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.example.com/modules/ModuleA_2 -->
+
+    <owl:NamedIndividual rdf:about="http://www.example.com/modules/ModuleA_2">
+        <rdf:type rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/Module"/>
+        <AnnotationVocabulary:hasMaturityLevel rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/Informative"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.example.com/modules/ModuleA_3 -->
+
+    <owl:NamedIndividual rdf:about="http://www.example.com/modules/ModuleA_3">
+        <rdf:type rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/Module"/>
+        <AnnotationVocabulary:hasMaturityLevel rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/Release"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.example.com/modules/ModuleB -->
+
+    <owl:NamedIndividual rdf:about="http://www.example.com/modules/ModuleB">
+        <rdf:type rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/Module"/>
+        <terms:hasPart rdf:resource="http://www.example.com/modules/ModuleB_1"/>
+        <terms:hasPart rdf:resource="http://www.example.com/modules/ModuleB_2"/>
+        <AnnotationVocabulary:hasMaturityLevel rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/Provisional"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.example.com/modules/ModuleB_1 -->
+
+    <owl:NamedIndividual rdf:about="http://www.example.com/modules/ModuleB_1">
+        <rdf:type rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/Module"/>
+        <AnnotationVocabulary:hasMaturityLevel rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/Provisional"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.example.com/modules/ModuleB_2 -->
+
+    <owl:NamedIndividual rdf:about="http://www.example.com/modules/ModuleB_2">
+        <rdf:type rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/Module"/>
+        <AnnotationVocabulary:hasMaturityLevel rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/Provisional"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- http://www.example.com/modules/ModuleC -->
+
+    <owl:NamedIndividual rdf:about="http://www.example.com/modules/ModuleC">
+        <rdf:type rdf:resource="http://www.omg.org/techprocess/ab/SpecificationMetadata/Module"/>
+        <AnnotationVocabulary:hasMaturityLevel rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/Release"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/Informative -->
+
+    <owl:NamedIndividual rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/Informative">
+        <rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/MaturityLevel"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/Provisional -->
+
+    <owl:NamedIndividual rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/Provisional">
+        <rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/MaturityLevel"/>
+    </owl:NamedIndividual>
+    
+
+
+    <!-- https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/Release -->
+
+    <owl:NamedIndividual rdf:about="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/Release">
+        <rdf:type rdf:resource="https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/MaturityLevel"/>
+    </owl:NamedIndividual>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
+

--- a/onto-viewer-toolkit/README.md
+++ b/onto-viewer-toolkit/README.md
@@ -13,17 +13,18 @@ OntoViewer Toolkit can be run with a few different goals that are described belo
 
 ## Options
 
-| Name                  | Description                                                                                                                                             | Example                                                                    |
-|-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------|
-| `data`                | Path to the input ontology                                                                                                                              | `ontology/example.rdf`                                                     |
-| `extract-data-column` | Used for specifying property IRI for specific column in extract-data output. Supported values: definition, example, explanatoryNote, synonym, usageNote | `synonym=http://example.com/synonym`                                       |
-| `filter-pattern`  | String that should be within entity's IRI to include it                                                                                                 | `test`                                                                     |
-| `goal`    | Specify which goal should be executed by the toolkit                                                                                                    | `extract-data`                                                             |
-| `maturity-level` | Override default maturity levels; should have format 'maturityLevelIri=label'                                                                           | `maturity-level https://example.com/Provisional=Provisional` |
-| `ontology-iri` | New IRI for merged ontology                                                                                                                             | `http://example.com/ontology` |
-| `ontology-mapping` | Path to the catalog file with ontology mapping                                                                                                          | `catalog-v001.xml` |
-| `ontology-version-iri` | New version IRI for merged ontology                                                                                                                     | `http://example.com/ontology1/v1` |
-| `output` | Path where the result will be saved                                                                                                                     | `output.rdf` |
+| Name                      | Description                                                                                                                                            | Example                                                        |
+|---------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------|
+| `data`                    | Path to the input ontology                                                                                                                             | `ontology/example.rdf`                                         |
+| `extract-data-column`     | Used for specifying property IRI for specific column in extract-data output. Supported values: definition, example, explanatoryNote, synonym, usageNote | `synonym=http://example.com/synonym`                           |
+| `filter-pattern`          | String that should be within entity's IRI to include it                                                                                                | `test`                                                         |
+| `goal`                    | Specify which goal should be executed by the toolkit                                                                                                   | `extract-data`                                                 |
+| `maturity-level`          | Override default maturity levels; should have format 'maturityLevelIri=label'                                                                          | `https://example.com/Provisional=Provisional`   |
+| `maturity-level-property` | Override default maturity level property                                                                   | `https://example.com/hasMaturityLevel` |
+| `ontology-iri`            | New IRI for merged ontology                                                                                                                            | `http://example.com/ontology`                                  |
+| `ontology-mapping`        | Path to the catalog file with ontology mapping                                                                                                         | `catalog-v001.xml`                                             |
+| `ontology-version-iri`    | New version IRI for merged ontology                                                                                                                    | `http://example.com/ontology1/v1`                              |
+| `output`                  | Path where the result will be saved                                                                                                                    | `output.rdf`                                                   |
 
 
 
@@ -64,6 +65,19 @@ java -jar onto-viewer-toolkit.jar \
     --maturity-level https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/Provisional=Provisional \
     --output extracted-data.csv
 ```
+
+
+#### `extract-data with maturity-level and maturity-level-property`
+
+```bash
+java -jar onto-viewer-toolkit.jar \
+    --goal extract-data \
+    --data my-ontology.rdf \
+    --maturity-level https://spec.industrialontologies.org/ontology/core/meta/AnnotationVocabulary/Provisional=Provisional \
+    --maturity-level-property https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/AnnotationVocabulary/hasMaturityLevel \
+    --output extracted-data.csv
+```
+
 
 #### `extract-data with extract-data-column`
 

--- a/onto-viewer-toolkit/src/main/java/org/edmcouncil/spec/ontoviewer/toolkit/OntoViewerToolkitCommandLine.java
+++ b/onto-viewer-toolkit/src/main/java/org/edmcouncil/spec/ontoviewer/toolkit/OntoViewerToolkitCommandLine.java
@@ -2,6 +2,7 @@ package org.edmcouncil.spec.ontoviewer.toolkit;
 
 import static org.edmcouncil.spec.ontoviewer.toolkit.options.OptionDefinition.EXTRACT_DATA_COLUMN;
 import static org.edmcouncil.spec.ontoviewer.toolkit.options.OptionDefinition.MATURITY_LEVEL;
+import static org.edmcouncil.spec.ontoviewer.toolkit.options.OptionDefinition.MATURITY_LEVEL_PROPERTY;
 import static org.edmcouncil.spec.ontoviewer.toolkit.options.OptionDefinition.ONTOLOGY_IRI;
 import static org.edmcouncil.spec.ontoviewer.toolkit.options.OptionDefinition.ONTOLOGY_MAPPING;
 import static org.edmcouncil.spec.ontoviewer.toolkit.options.OptionDefinition.ONTOLOGY_VERSION_IRI;
@@ -295,6 +296,12 @@ public class OntoViewerToolkitCommandLine implements CommandLineRunner {
           .collect(Collectors.toMap(PairWithList::getLabel, PairWithList::getIris));
 
       configurationData.getToolkitConfig().setExtractDataColumns(extractDataColumns);
+    }
+
+    var maturityLevelPropertyOptions = commandLineOptions.getOptions(MATURITY_LEVEL_PROPERTY);
+    if (maturityLevelPropertyOptions != null && !maturityLevelPropertyOptions.isEmpty()) {
+      var maturityLevelProperty = maturityLevelPropertyOptions.get(0);
+      configurationData.getOntologiesConfig().setMaturityLevelProperty(maturityLevelProperty);
     }
 
     var goal = commandLineOptions.getOption(OptionDefinition.GOAL).or(() -> {

--- a/onto-viewer-toolkit/src/main/java/org/edmcouncil/spec/ontoviewer/toolkit/options/OptionDefinition.java
+++ b/onto-viewer-toolkit/src/main/java/org/edmcouncil/spec/ontoviewer/toolkit/options/OptionDefinition.java
@@ -10,6 +10,8 @@ public enum OptionDefinition {
     "specify which goal should be executed by toolkit", Goal.EXTRACT_DATA.getName()),
   MATURITY_LEVEL("maturity-level", true, false,
       "override default maturity levels; should have format '<maturityLevelIri>=<label>'"),
+  MATURITY_LEVEL_PROPERTY("maturity-level-property", true, false,
+      "set maturity level property that is used to extract maturity levels"),
   ONTOLOGY_IRI("ontology-iri", true, false, "new IRI for merged ontology"),
   ONTOLOGY_MAPPING("ontology-mapping", true, false,
       "path to the catalog file with ontology mapping", null),

--- a/onto-viewer-toolkit/src/test/java/org/edmcouncil/spec/ontoviewer/toolkit/handlers/OntologyTableDataExtractorTest.java
+++ b/onto-viewer-toolkit/src/test/java/org/edmcouncil/spec/ontoviewer/toolkit/handlers/OntologyTableDataExtractorTest.java
@@ -84,7 +84,7 @@ class OntologyTableDataExtractorTest {
         "A is a kind of Thing.",
         "'A' example",
         "'A' explanatory note",
-        "Not Set",
+        "Release",
         false, 
         null);
 
@@ -105,7 +105,7 @@ class OntologyTableDataExtractorTest {
         "",
         "",
         "",
-        "Not Set", 
+        "Release",
         false, 
         null);
 
@@ -126,7 +126,7 @@ class OntologyTableDataExtractorTest {
         "'B1' object property label is a kind of topObjectProperty.",
         "",
         "",
-        "Not Set",
+        "Release",
         false,
         null);
 
@@ -147,7 +147,7 @@ class OntologyTableDataExtractorTest {
         "'C1' data property label is a kind of topDataProperty.",
         "",
         "'C1' explanatory note",
-        "Not Set",
+        "Release",
         false, 
         null);
 


### PR DESCRIPTION
## Description

Currently onto-viewer-toolkit generates maturity levels only for those resources that have these levels explicitly stated.
We should have it fixed so that it will inherit the maturity levels from the ontologies where the resources without such explicit statements are defined.

Fixes #341 


`--goal extract-data --data C:\Users\x\Desktop\idmp\AboutIDMPDev-ReferenceIndividuals.rdf --filter-pattern idmp --ontology-mapping C:\Users\x\Desktop\idmp\catalog-v001.xml --output extracted-data.csv --maturity-level https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/Release=Release --maturity-level https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/Provisional=Provisional --maturity-level https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/Informative=Informative --maturity-level https://spec.pistoiaalliance.org/idmp/ontology/META/ChangeManagement/Preliminary=Preliminary`