### PR TITLE
Empty qnames for bnodes

### DIFF
--- a/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/classes/ClassHandler.java
+++ b/onto-viewer-core/src/main/java/org/edmcouncil/spec/ontoviewer/core/ontology/data/handler/classes/ClassHandler.java
@@ -240,7 +240,7 @@ public class ClassHandler {
     if (classIri != null) {
       resultDetails.addAllProperties(copyrightHandler.getCopyright(classIri));
       resultDetails.addAllProperties(licenseHandler.getLicense(classIri));
-      resultDetails.setqName(qnameHandler.getQName(classIri));
+      resultDetails.setqName(new String());
     }
     
     if (ontologyGraph.isEmpty()) {


### PR DESCRIPTION
This fixes the bug of qnames for bnodes - they should be empty.